### PR TITLE
Added x:Name and x:Key info to breadcrumb info

### DIFF
--- a/XamlStudio/Views/Document.xaml.cs
+++ b/XamlStudio/Views/Document.xaml.cs
@@ -643,11 +643,25 @@ public sealed partial class Document : UserControl,
         {
             if (node is IXmlElementSyntax element)
             {
-                var loc = text.GetLineColumnIndex(node.Span.Start);
+                var (line, column) = text.GetLineColumnIndex(node.Span.Start);
+                var xName = element.GetAttributeValue("Name", "x");
+                var xKey = element.GetAttributeValue("Key", "x");
+
+                // Construct a display name using the element type, x:Name, and x:Key
+                string displayName = element.Name;
+                if (xName is not null)
+                {
+                    displayName = $"{xName} ({element.Name})";
+                }
+                else if (xKey is not null)
+                {
+                    displayName = $"{xKey} ({element.Name})";
+                }
+
                 Breadcrumbs.Insert(0, new BreadcrumbInfo()
                 {
-                    Name = element.Name,
-                    Location = new Position((uint)loc.Line, (uint)loc.Column),
+                    Name = displayName,
+                    Location = new Position((uint)line, (uint)column),
                     // TODO: Put child sister nodes in a list so that can have drop-down to navigate within document?
                 });
             }

--- a/XamlStudio/Views/Document.xaml.cs
+++ b/XamlStudio/Views/Document.xaml.cs
@@ -651,11 +651,11 @@ public sealed partial class Document : UserControl,
                 string displayName = element.Name;
                 if (xName is not null)
                 {
-                    displayName = $"{xName} ({element.Name})";
+                    displayName = $"{xName} [{element.Name}]";
                 }
                 else if (xKey is not null)
                 {
-                    displayName = $"{xKey} ({element.Name})";
+                    displayName = $"{xKey} [{element.Name}]";
                 }
 
                 Breadcrumbs.Insert(0, new BreadcrumbInfo()


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! ⚠ -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## ~~Fixes~~ Discussed in #37 

<!-- Add the relevant issue number after the word "Fixes" mentioned above (for ex: `## Fixes #0000`) which will automatically close the issue once the PR is merged. -->

<!-- PRs without assigned issues will be closed unless minor changes to documentation/typos. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->

<!-- - Bugfix -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
- Other... Please describe: **Feature Improvement**

## What is the current behavior?

All elements in the BreadcrumbBar will simply display their type.

## What is the new behavior?

Elements will an `x:Name` or an `x:Key` atttribute will display as `"Name/Key (Type)"`. If both `x:Name` and  `x:Key` are assigned, `x:Name` will be used.

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest dev branch of XAML Studio
- [x] Tested code with current supported SDKs
- [ ] Tests for the changes have been added (if applicable)
- [x] License Header has been added to all new source files
- [x] Contains **NO** breaking changes to save/state files

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->
