### PR TITLE
Refactored codebase to make more extensive use of more modern C# features.

### DIFF
--- a/Microsoft.Toolkit.Future/Adorners/AdornerLayer.cs
+++ b/Microsoft.Toolkit.Future/Adorners/AdornerLayer.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -16,20 +16,14 @@ namespace CommunityToolkit.WinUI.Controls.Future;
 /// </summary>
 public partial class AdornerLayer : Canvas
 {
-    public static UIElement GetXaml(FrameworkElement obj)
-    {
-        return (UIElement)obj.GetValue(XamlProperty);
-    }
+    public static UIElement GetXaml(FrameworkElement obj) => (UIElement)obj.GetValue(XamlProperty);
 
     /// <summary>
     /// Sets the <see cref="XamlProperty"/> of a <see cref="FrameworkElement"/>. Use this to attach any <see cref="UIElement"/> as an adorner to another <see cref="FrameworkElement"/>. Requires that an <see cref="AdornerLayer"/> is available in the visual tree above the adorned element.
     /// </summary>
     /// <param name="obj"></param>
     /// <param name="value"></param>
-    public static void SetXaml(FrameworkElement obj, UIElement value)
-    {
-        obj.SetValue(XamlProperty, value);
-    }
+    public static void SetXaml(FrameworkElement obj, UIElement value) => obj.SetValue(XamlProperty, value);
 
     /// <summary>
     /// Identifies the Xaml Attached Property.

--- a/Microsoft.Toolkit.Future/Converters/CollectionContainsConverter.cs
+++ b/Microsoft.Toolkit.Future/Converters/CollectionContainsConverter.cs
@@ -35,7 +35,5 @@ public class CollectionContainsConverter : DependencyObject, IValueConverter // 
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, string language)
-    {
-        throw new NotImplementedException();
-    }
+        => throw new NotImplementedException();
 }

--- a/Microsoft.Toolkit.Future/Data/Grouping.cs
+++ b/Microsoft.Toolkit.Future/Data/Grouping.cs
@@ -12,42 +12,25 @@ using Windows.UI.Xaml.Data;
 
 namespace Microsoft.Toolkit.Future.Data;
 
-public class Grouping<TKey, TElement> : IGrouping<TKey, TElement>, IEnumerable<TElement>, IEnumerable, ICollectionViewGroup
+public class Grouping<TKey, TElement>(TKey key, IEnumerable<TElement> items) : IGrouping<TKey, TElement>, IEnumerable<TElement>, IEnumerable, ICollectionViewGroup
 {
     public object Group => Key;
 
     public IObservableVector<object> GroupItems => (IObservableVector<object>)new ObservableCollection<object>((IEnumerable<object>)this);
 
-    public TKey Key { get; private set; }
+    public TKey Key { get; private set; } = key;
 
-    private IEnumerable<TElement> Items { get; }
+    public IEnumerator<TElement> GetEnumerator() => items.GetEnumerator();
 
-    public Grouping(TKey key, IEnumerable<TElement> items)
-    {
-        Key = key;
-        Items = items;
-    }
+    IEnumerator IEnumerable.GetEnumerator() => items.GetEnumerator();
 
-    public IEnumerator<TElement> GetEnumerator()
-    {
-        return Items.GetEnumerator();
-    }
-
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        return Items.GetEnumerator();
-    }
-
-    public override string ToString()
-    {
-        return Key?.ToString();
-    }
+    public override string ToString() => Key?.ToString();
 }
 
 public static class EnumerableExtensions
 {
     public static Grouping<TKey, TElement> ToGroup<TKey, TElement>(this IEnumerable<TElement> list, TKey key)
-        => new Grouping<TKey, TElement>(key, list);
+        => new(key, list);
 
     public static IEnumerable<Grouping<TKey, TElement>> ToGroup<TKey, TElement>(this IEnumerable<TElement> list, Func<TElement, TKey> keySelector)
         => list.GroupBy(keySelector, (key, items) => new Grouping<TKey, TElement>(key, items));
@@ -57,5 +40,5 @@ public static class GroupingExtensions
 {
     // Converts a System Group to this Group.
     public static Grouping<TKey, TElement> ToGroup<TKey, TElement>(this IGrouping<TKey, TElement> group)
-        => new Grouping<TKey, TElement>(group.Key, group.AsEnumerable());
+        => new(group.Key, group.AsEnumerable());
 }

--- a/Microsoft.Toolkit.Future/Extensions/Bind.Boolean.cs
+++ b/Microsoft.Toolkit.Future/Extensions/Bind.Boolean.cs
@@ -8,78 +8,33 @@ namespace CommunityToolkit.WinUI.Extensions.Future;
 
 public static partial class Bind
 {
-    public static bool And(bool value1, bool value2)
-    {
-        return value1 && value2;
-    }
+    public static bool And(bool value1, bool value2) => value1 && value2;
 
-    public static bool Or(bool value1, bool value2)
-    {
-        return value1 || value2;
-    }
+    public static bool Or(bool value1, bool value2) => value1 || value2;
 
-    public static bool Not(bool value)
-    {
-        return !value;
-    }
+    public static bool Not(bool value) => !value;
 
-    public static bool GreaterThan(int lhs, int rhs)
-    {
-        return lhs > rhs;
-    }
+    public static bool GreaterThan(int lhs, int rhs) => lhs > rhs;
 
-    public static bool GreaterThan(double lhs, double rhs)
-    {
-        return lhs > rhs;
-    }
+    public static bool GreaterThan(double lhs, double rhs) => lhs > rhs;
 
-    public static bool LessThan(int lhs, int rhs)
-    {
-        return lhs < rhs;
-    }
+    public static bool LessThan(int lhs, int rhs) => lhs < rhs;
 
-    public static bool LessThan(double lhs, double rhs)
-    {
-        return lhs < rhs;
-    }
+    public static bool LessThan(double lhs, double rhs) => lhs < rhs;
 
-    public static bool GreaterThanOrEqualTo(int lhs, int rhs)
-    {
-        return lhs >= rhs;
-    }
+    public static bool GreaterThanOrEqualTo(int lhs, int rhs) => lhs >= rhs;
 
-    public static bool GreaterThanOrEqualTo(double lhs, double rhs)
-    {
-        return lhs >= rhs;
-    }
+    public static bool GreaterThanOrEqualTo(double lhs, double rhs) => lhs >= rhs;
 
-    public static bool LessThanOrEqualTo(int lhs, int rhs)
-    {
-        return lhs <= rhs;
-    }
+    public static bool LessThanOrEqualTo(int lhs, int rhs) => lhs <= rhs;
 
-    public static bool LessThanOrEqualTo(double lhs, double rhs)
-    {
-        return lhs <= rhs;
-    }
+    public static bool LessThanOrEqualTo(double lhs, double rhs) => lhs <= rhs;
 
-    public static bool EqualTo(int lhs, int rhs)
-    {
-        return lhs == rhs;
-    }
+    public static bool EqualTo(int lhs, int rhs) => lhs == rhs;
 
-    public static bool EqualTo(double lhs, double rhs, double tolerance = 0.0)
-    {
-        return Math.Abs(lhs - rhs) <= tolerance;
-    }
+    public static bool EqualTo(double lhs, double rhs, double tolerance = 0.0) => Math.Abs(lhs - rhs) <= tolerance;
 
-    public static bool NotEqualTo(int lhs, int rhs)
-    {
-        return lhs != rhs;
-    }
+    public static bool NotEqualTo(int lhs, int rhs) => lhs != rhs;
 
-    public static bool NotEqualTo(double lhs, double rhs, double tolerance = 0.0)
-    {
-        return !EqualTo(lhs, rhs, tolerance);
-    }
+    public static bool NotEqualTo(double lhs, double rhs, double tolerance = 0.0) => !EqualTo(lhs, rhs, tolerance);
 }

--- a/Microsoft.Toolkit.Future/Extensions/Bind.Math.cs
+++ b/Microsoft.Toolkit.Future/Extensions/Bind.Math.cs
@@ -59,13 +59,7 @@ public static partial class Bind
         return result;
     }
 
-    public static double Divide(double value, double factor)
-    {
-        return value / factor;
-    }
+    public static double Divide(double value, double factor) => value / factor;
 
-    public static double Clamp(double value, double min, double max)
-    {
-        return Math.Min(max, Math.Max(min, value));
-    }
+    public static double Clamp(double value, double min, double max) => Math.Min(max, Math.Max(min, value));
 }

--- a/Microsoft.Toolkit.Future/Extensions/Bind.Visibility.cs
+++ b/Microsoft.Toolkit.Future/Extensions/Bind.Visibility.cs
@@ -10,90 +10,39 @@ namespace CommunityToolkit.WinUI.Extensions.Future;
 
 public static partial class Bind
 {
-    public static Visibility AndV(bool value1, bool value2)
-    {
-        return (value1 && value2) ? Visibility.Visible : Visibility.Collapsed;
-    }
+    public static Visibility AndV(bool value1, bool value2) => (value1 && value2) ? Visibility.Visible : Visibility.Collapsed;
 
-    public static Visibility OrV(bool value1, bool value2)
-    {
-        return (value1 || value2) ? Visibility.Visible : Visibility.Collapsed;
-    }
+    public static Visibility OrV(bool value1, bool value2) => (value1 || value2) ? Visibility.Visible : Visibility.Collapsed;
 
-    public static Visibility NotV(bool value)
-    {
-        return !value ? Visibility.Visible : Visibility.Collapsed;
-    }
+    public static Visibility NotV(bool value) => !value ? Visibility.Visible : Visibility.Collapsed;
 
-    public static Visibility GreaterThanV(int lhs, int rhs)
-    {
-        return lhs > rhs ? Visibility.Visible : Visibility.Collapsed;
-    }
+    public static Visibility GreaterThanV(int lhs, int rhs) => lhs > rhs ? Visibility.Visible : Visibility.Collapsed;
 
-    public static Visibility GreaterThanV(double lhs, double rhs)
-    {
-        return lhs > rhs ? Visibility.Visible : Visibility.Collapsed;
-    }
+    public static Visibility GreaterThanV(double lhs, double rhs) => lhs > rhs ? Visibility.Visible : Visibility.Collapsed;
 
-    public static Visibility LessThanV(int lhs, int rhs)
-    {
-        return lhs < rhs ? Visibility.Visible : Visibility.Collapsed;
-    }
+    public static Visibility LessThanV(int lhs, int rhs) => lhs < rhs ? Visibility.Visible : Visibility.Collapsed;
 
-    public static Visibility LessThanV(double lhs, double rhs)
-    {
-        return lhs < rhs ? Visibility.Visible : Visibility.Collapsed;
-    }
+    public static Visibility LessThanV(double lhs, double rhs) => lhs < rhs ? Visibility.Visible : Visibility.Collapsed;
 
-    public static Visibility GreaterThanOrEqualToV(int lhs, int rhs)
-    {
-        return lhs >= rhs ? Visibility.Visible : Visibility.Collapsed;
-    }
+    public static Visibility GreaterThanOrEqualToV(int lhs, int rhs) => lhs >= rhs ? Visibility.Visible : Visibility.Collapsed;
 
-    public static Visibility GreaterThanOrEqualToV(double lhs, double rhs)
-    {
-        return lhs >= rhs ? Visibility.Visible : Visibility.Collapsed;
-    }
+    public static Visibility GreaterThanOrEqualToV(double lhs, double rhs) => lhs >= rhs ? Visibility.Visible : Visibility.Collapsed;
 
-    public static Visibility LessThanOrEqualToV(int lhs, int rhs)
-    {
-        return lhs <= rhs ? Visibility.Visible : Visibility.Collapsed;
-    }
+    public static Visibility LessThanOrEqualToV(int lhs, int rhs) => lhs <= rhs ? Visibility.Visible : Visibility.Collapsed;
 
-    public static Visibility LessThanOrEqualToV(double lhs, double rhs)
-    {
-        return lhs <= rhs ? Visibility.Visible : Visibility.Collapsed;
-    }
+    public static Visibility LessThanOrEqualToV(double lhs, double rhs) => lhs <= rhs ? Visibility.Visible : Visibility.Collapsed;
 
-    public static Visibility EqualToV(object lhs, object rhs)
-    {
-        return lhs == rhs ? Visibility.Visible : Visibility.Collapsed;
-    }
+    public static Visibility EqualToV(object lhs, object rhs) => lhs == rhs ? Visibility.Visible : Visibility.Collapsed;
 
-    public static Visibility EqualToV(int lhs, int rhs)
-    {
-        return lhs == rhs ? Visibility.Visible : Visibility.Collapsed;
-    }
+    public static Visibility EqualToV(int lhs, int rhs) => lhs == rhs ? Visibility.Visible : Visibility.Collapsed;
 
-    public static Visibility EqualToV(double lhs, double rhs, double tolerance = 0.0)
-    {
-        return Math.Abs(lhs - rhs) <= tolerance ? Visibility.Visible : Visibility.Collapsed;
-    }
+    public static Visibility EqualToV(double lhs, double rhs, double tolerance = 0.0) => Math.Abs(lhs - rhs) <= tolerance ? Visibility.Visible : Visibility.Collapsed;
 
-    public static Visibility NotEqualToV(object lhs, object rhs)
-    {
-        return lhs != rhs ? Visibility.Visible : Visibility.Collapsed;
-    }
+    public static Visibility NotEqualToV(object lhs, object rhs) => lhs != rhs ? Visibility.Visible : Visibility.Collapsed;
 
-    public static Visibility NotEqualToV(int lhs, int rhs)
-    {
-        return lhs != rhs ? Visibility.Visible : Visibility.Collapsed;
-    }
+    public static Visibility NotEqualToV(int lhs, int rhs) => lhs != rhs ? Visibility.Visible : Visibility.Collapsed;
 
-    public static Visibility NotEqualToV(double lhs, double rhs, double tolerance = 0.0)
-    {
-        return !EqualTo(lhs, rhs, tolerance) ? Visibility.Visible : Visibility.Collapsed;
-    }
+    public static Visibility NotEqualToV(double lhs, double rhs, double tolerance = 0.0) => !EqualTo(lhs, rhs, tolerance) ? Visibility.Visible : Visibility.Collapsed;
 
     public static Visibility AnyV(ICollection? collection) => collection?.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
 }

--- a/Microsoft.Toolkit.Future/Extensions/Bind.cs
+++ b/Microsoft.Toolkit.Future/Extensions/Bind.cs
@@ -11,18 +11,9 @@ public static partial class Bind
 {
     private static ResourceLoader _resLoader = ResourceLoader.GetForCurrentView();
 
-    public static string LocalizedString(string resourceKey)
-    {
-        return _resLoader.GetString(resourceKey);
-    }
+    public static string LocalizedString(string resourceKey) => _resLoader.GetString(resourceKey);
 
-    public static Visibility NotVisible(bool value)
-    {
-        return value ? Visibility.Collapsed : Visibility.Visible;
-    }
+    public static Visibility NotVisible(bool value) => value ? Visibility.Collapsed : Visibility.Visible;
 
-    public static Visibility Visible(bool value)
-    {
-        return value ? Visibility.Visible : Visibility.Collapsed;
-    }
+    public static Visibility Visible(bool value) => value ? Visibility.Visible : Visibility.Collapsed;
 }

--- a/Microsoft.Toolkit.Future/Extensions/ContentPresenter/ContentPresenterExtensions.cs
+++ b/Microsoft.Toolkit.Future/Extensions/ContentPresenter/ContentPresenterExtensions.cs
@@ -12,28 +12,20 @@ namespace CommunityToolkit.WinUI.Extensions.Future;
 public static class ContentPresenterExtensions
 {
     public static bool GetUpdateTemplateSelectorOnContentChange(ContentPresenter obj)
-    {
-        return (bool)obj.GetValue(UpdateTemplateSelectorOnContentChangeProperty);
-    }
+        => (bool)obj.GetValue(UpdateTemplateSelectorOnContentChangeProperty);
 
     public static void SetUpdateTemplateSelectorOnContentChange(ContentPresenter obj, bool value)
-    {
-        obj.SetValue(UpdateTemplateSelectorOnContentChangeProperty, value);
-    }
+        => obj.SetValue(UpdateTemplateSelectorOnContentChangeProperty, value);
 
     // Using a DependencyProperty as the backing store for UpdateTemplateSelectorOnContentChange.  This enables animation, styling, binding, etc...
     public static readonly DependencyProperty UpdateTemplateSelectorOnContentChangeProperty =
         DependencyProperty.RegisterAttached("UpdateTemplateSelectorOnContentChange", typeof(bool), typeof(ContentPresenterExtensions), new PropertyMetadata(false, OnUpdateTemplateSelectorOnContentChange));
 
     private static long GetContentChangedToken(ContentPresenter obj)
-    {
-        return (long)obj.GetValue(ContentChangedTokenProperty);
-    }
+        => (long)obj.GetValue(ContentChangedTokenProperty);
 
     private static void SetContentChangedToken(ContentPresenter obj, long value)
-    {
-        obj.SetValue(ContentChangedTokenProperty, value);
-    }
+        => obj.SetValue(ContentChangedTokenProperty, value);
 
     // Using a DependencyProperty as the backing store for ContentChangedToken.  This enables animation, styling, binding, etc...
     private static readonly DependencyProperty ContentChangedTokenProperty =

--- a/Microsoft.Toolkit.Future/Extensions/FrameworkElement/FrameworkElementExtensions.cs
+++ b/Microsoft.Toolkit.Future/Extensions/FrameworkElement/FrameworkElementExtensions.cs
@@ -12,42 +12,30 @@ namespace CommunityToolkit.WinUI.Extensions.Future;
 public static partial class FrameworkElementExtensions
 {
     public static bool GetUpdateLiveRegionChangedOnVisible(FrameworkElement obj)
-    {
-        return (bool)obj.GetValue(UpdateLiveRegionChangedOnVisibleProperty);
-    }
+        => (bool)obj.GetValue(UpdateLiveRegionChangedOnVisibleProperty);
 
     public static void SetUpdateLiveRegionChangedOnVisible(FrameworkElement obj, bool value)
-    {
-        obj.SetValue(UpdateLiveRegionChangedOnVisibleProperty, value);
-    }
+        => obj.SetValue(UpdateLiveRegionChangedOnVisibleProperty, value);
 
     // Using a DependencyProperty as the backing store for UpdateLiveRegionChangedOnVisible.  This enables animation, styling, binding, etc...
     public static readonly DependencyProperty UpdateLiveRegionChangedOnVisibleProperty =
         DependencyProperty.RegisterAttached("UpdateLiveRegionChangedOnVisible", typeof(bool), typeof(FrameworkElementExtensions), new PropertyMetadata(false, UpdateLiveRegionChangedOnVisible_Changed));
 
     public static bool GetUpdateLiveRegionChangedOnLoad(DependencyObject obj)
-    {
-        return (bool)obj.GetValue(UpdateLiveRegionChangedOnLoadProperty);
-    }
+        => (bool)obj.GetValue(UpdateLiveRegionChangedOnLoadProperty);
 
     public static void SetUpdateLiveRegionChangedOnLoad(DependencyObject obj, bool value)
-    {
-        obj.SetValue(UpdateLiveRegionChangedOnLoadProperty, value);
-    }
+        => obj.SetValue(UpdateLiveRegionChangedOnLoadProperty, value);
 
     // Using a DependencyProperty as the backing store for UpdateLiveRegionChangedOnLoad.  This enables animation, styling, binding, etc...
     public static readonly DependencyProperty UpdateLiveRegionChangedOnLoadProperty =
         DependencyProperty.RegisterAttached("UpdateLiveRegionChangedOnLoad", typeof(bool), typeof(FrameworkElementExtensions), new PropertyMetadata(false, UpdateLiveRegionChangedOnLoad_Changed));
 
     public static bool GetUpdateLiveRegionChildren(DependencyObject obj)
-    {
-        return (bool)obj.GetValue(UpdateLiveRegionChildrenProperty);
-    }
+        => (bool)obj.GetValue(UpdateLiveRegionChildrenProperty);
 
     public static void SetUpdateLiveRegionChildren(DependencyObject obj, bool value)
-    {
-        obj.SetValue(UpdateLiveRegionChildrenProperty, value);
-    }
+        => obj.SetValue(UpdateLiveRegionChildrenProperty, value);
 
     // Using a DependencyProperty as the backing store for UpdateLiveRegionChildren.  This enables animation, styling, binding, etc...
     public static readonly DependencyProperty UpdateLiveRegionChildrenProperty =

--- a/Microsoft.Toolkit.Future/Extensions/ListBox/ListBoxExtensions.cs
+++ b/Microsoft.Toolkit.Future/Extensions/ListBox/ListBoxExtensions.cs
@@ -15,25 +15,13 @@ public static class ListBoxExtensions
                                             typeof(ListBoxExtensions),
                                             new PropertyMetadata(false, OnAllowDeselectionChanged));
 
-    public static bool GetAllowDeselection(DependencyObject obj)
-    {
-        return (bool)obj.GetValue(AllowDeselectionProperty);
-    }
+    public static bool GetAllowDeselection(DependencyObject obj) => (bool)obj.GetValue(AllowDeselectionProperty);
 
-    public static void SetAllowDeselection(DependencyObject obj, bool value)
-    {
-        obj.SetValue(AllowDeselectionProperty, value);
-    }
+    public static void SetAllowDeselection(DependencyObject obj, bool value) => obj.SetValue(AllowDeselectionProperty, value);
 
-    public static object GetSelectedObject(DependencyObject obj)
-    {
-        return (object)obj.GetValue(SelectedObjectProperty);
-    }
+    public static object GetSelectedObject(DependencyObject obj) => (object)obj.GetValue(SelectedObjectProperty);
 
-    public static void SetSelectedObject(DependencyObject obj, object value)
-    {
-        obj.SetValue(SelectedObjectProperty, value);
-    }
+    public static void SetSelectedObject(DependencyObject obj, object value) => obj.SetValue(SelectedObjectProperty, value);
 
     // Using a DependencyProperty as the backing store for SelectedObject.  This enables animation, styling, binding, etc...
     public static readonly DependencyProperty SelectedObjectProperty =

--- a/Microsoft.Toolkit.Future/Extensions/Mouse.cs
+++ b/Microsoft.Toolkit.Future/Extensions/Mouse.cs
@@ -15,10 +15,10 @@ namespace CommunityToolkit.WinUI.Extensions.Future;
 /// </summary>
 public class Mouse
 {
-    private static readonly object _cursorLock = new object();
-    private static readonly CoreCursor _defaultCursor = new CoreCursor(CoreCursorType.Arrow, 1);
+    private static readonly object _cursorLock = new();
+    private static readonly CoreCursor _defaultCursor = new(CoreCursorType.Arrow, 1);
     private static readonly Dictionary<CoreCursorType, CoreCursor> _cursors =
-        new Dictionary<CoreCursorType, CoreCursor> { { CoreCursorType.Arrow, _defaultCursor } };
+        new() { { CoreCursorType.Arrow, _defaultCursor } };
 
     /// <summary>
     /// Dependency property for specifying the target <see cref="CoreCursorType"/> to be shown
@@ -32,20 +32,14 @@ public class Mouse
     /// </summary>
     /// <param name="element">Object where the selector cursor type should be shown.</param>
     /// <param name="value">Target cursor type value.</param>
-    public static void SetCursor(FrameworkElement element, CoreCursorType value)
-    {
-        element.SetValue(CursorProperty, value);
-    }
+    public static void SetCursor(FrameworkElement element, CoreCursorType value) => element.SetValue(CursorProperty, value);
 
     /// <summary>
     /// Get the current <see cref="CoreCursorType"/>.
     /// </summary>
     /// <param name="element">Object where the selector cursor type should be shown.</param>
     /// <returns>Cursor type set on target element.</returns>
-    public static CoreCursorType GetCursor(FrameworkElement element)
-    {
-        return (CoreCursorType)element.GetValue(CursorProperty);
-    }
+    public static CoreCursorType GetCursor(FrameworkElement element) => (CoreCursorType)element.GetValue(CursorProperty);
 
     private static void CursorChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
@@ -97,10 +91,8 @@ public class Mouse
         Window.Current.CoreWindow.PointerCursor = cursor;
     }
 
-    private static void ElementOnUnloaded(object sender, RoutedEventArgs routedEventArgs)
-    {
+    private static void ElementOnUnloaded(object sender, RoutedEventArgs routedEventArgs) =>
         // when the element is programatically unloaded, reset the cursor back to default
         // this is necessary when click triggers immediate change in layout and PointerExited is not called
         Window.Current.CoreWindow.PointerCursor = _defaultCursor;
-    }
 }

--- a/Microsoft.Toolkit.Future/Extensions/NavigationView/NavigationViewExtensions.cs
+++ b/Microsoft.Toolkit.Future/Extensions/NavigationView/NavigationViewExtensions.cs
@@ -23,20 +23,14 @@ public class NavigationViewExtensions
     /// </summary>
     /// <param name="obj">The <see cref="Windows.UI.Xaml.Controls.NavigationView"/>.</param>
     /// <returns>The selected index.</returns>
-    public static int GetSelectedIndex(NavigationView obj)
-    {
-        return (int)obj.GetValue(SelectedIndexProperty);
-    }
+    public static int GetSelectedIndex(NavigationView obj) => (int)obj.GetValue(SelectedIndexProperty);
 
     /// <summary>
     /// Sets the index of the selected <see cref="NavigationViewItem"/>.
     /// </summary>
     /// <param name="obj">The <see cref="Windows.UI.Xaml.Controls.NavigationView"/>.</param>
     /// <param name="value">The index to select.</param>
-    public static void SetSelectedIndex(NavigationView obj, int value)
-    {
-        obj.SetValue(SelectedIndexProperty, value);
-    }
+    public static void SetSelectedIndex(NavigationView obj, int value) => obj.SetValue(SelectedIndexProperty, value);
 
     /// <summary>
     /// Attached <see cref="DependencyProperty"/> for binding the selected index of a <see cref="NavigationView"/>.
@@ -48,20 +42,14 @@ public class NavigationViewExtensions
     /// </summary>
     /// <param name="obj">The <see cref="Windows.UI.Xaml.Controls.NavigationView"/>.</param>
     /// <returns>True if the settings page is selected.</returns>
-    public static bool GetIsSettingsSelected(NavigationView obj)
-    {
-        return (bool)obj.GetValue(IsSettingsSelectedProperty);
-    }
+    public static bool GetIsSettingsSelected(NavigationView obj) => (bool)obj.GetValue(IsSettingsSelectedProperty);
 
     /// <summary>
     /// Sets a value representing if the settings page is selected for the <see cref="NavigationViewItem"/>.
     /// </summary>
     /// <param name="obj">The <see cref="Windows.UI.Xaml.Controls.NavigationView"/>.</param>
     /// <param name="value">Set to True to select the settings page.</param>
-    public static void SetIsSettingsSelected(NavigationView obj, bool value)
-    {
-        obj.SetValue(IsSettingsSelectedProperty, value);
-    }
+    public static void SetIsSettingsSelected(NavigationView obj, bool value) => obj.SetValue(IsSettingsSelectedProperty, value);
 
     /// <summary>
     /// Attached <see cref="DependencyProperty"/> for selecting the Settings Page of a <see cref="NavigationView"/>.
@@ -74,20 +62,14 @@ public class NavigationViewExtensions
     /// </summary>
     /// <param name="obj">The <see cref="Windows.UI.Xaml.Controls.NavigationView"/>.</param>
     /// <returns>True if the feature is on.</returns>
-    public static bool GetCollapseOnClick(NavigationView obj)
-    {
-        return (bool)obj.GetValue(CollapseOnClickProperty);
-    }
+    public static bool GetCollapseOnClick(NavigationView obj) => (bool)obj.GetValue(CollapseOnClickProperty);
 
     /// <summary>
     /// Sets the behavior to collapse the content when clicking the already selected <see cref="NavigationViewItem"/>.
     /// </summary>
     /// <param name="obj">The <see cref="Windows.UI.Xaml.Controls.NavigationView"/>.</param>
     /// <param name="value">True to turn on this feature.</param>
-    public static void SetCollapseOnClick(NavigationView obj, bool value)
-    {
-        obj.SetValue(CollapseOnClickProperty, value);
-    }
+    public static void SetCollapseOnClick(NavigationView obj, bool value) => obj.SetValue(CollapseOnClickProperty, value);
 
     /// <summary>
     /// Attached <see cref="DependencyProperty"/> for enabling the behavior to collapse the <see cref="NavigationView"/> content when the same selected item is invoked again (click or tap).

--- a/Microsoft.Toolkit.Future/Extensions/Pivot/GetPivotCloseButtonCommandConverter.cs
+++ b/Microsoft.Toolkit.Future/Extensions/Pivot/GetPivotCloseButtonCommandConverter.cs
@@ -28,7 +28,5 @@ public class GetPivotCloseButtonCommandConverter : IValueConverter
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, string language)
-    {
-        throw new NotImplementedException();
-    }
+        => throw new NotImplementedException();
 }

--- a/Microsoft.Toolkit.Future/Extensions/Pivot/GetPivotGlyphConverter.cs
+++ b/Microsoft.Toolkit.Future/Extensions/Pivot/GetPivotGlyphConverter.cs
@@ -29,7 +29,5 @@ public class GetPivotGlyphConverter : GetPivotItemConverter
     }
 
     public override object ConvertBack(object value, Type targetType, object parameter, string language)
-    {
-        throw new NotImplementedException();
-    }
+        => throw new NotImplementedException();
 }

--- a/Microsoft.Toolkit.Future/Extensions/Pivot/GetPivotImageConverter.cs
+++ b/Microsoft.Toolkit.Future/Extensions/Pivot/GetPivotImageConverter.cs
@@ -28,7 +28,5 @@ public class GetPivotImageConverter : GetPivotItemConverter
     }
 
     public override object ConvertBack(object value, Type targetType, object parameter, string language)
-    {
-        throw new NotImplementedException();
-    }
+        => throw new NotImplementedException();
 }

--- a/Microsoft.Toolkit.Future/Extensions/Pivot/GetPivotItemConverter.cs
+++ b/Microsoft.Toolkit.Future/Extensions/Pivot/GetPivotItemConverter.cs
@@ -34,7 +34,5 @@ public class GetPivotItemConverter : IValueConverter
     }
 
     public virtual object ConvertBack(object value, Type targetType, object parameter, string language)
-    {
-        throw new NotImplementedException();
-    }
+        => throw new NotImplementedException();
 }

--- a/Microsoft.Toolkit.Future/Extensions/Pivot/PivotExtensions.Properties.cs
+++ b/Microsoft.Toolkit.Future/Extensions/Pivot/PivotExtensions.Properties.cs
@@ -21,9 +21,7 @@ public partial class PivotExtensions
     /// <param name="obj">The <see cref="Windows.UI.Xaml.Controls.Pivot"/> from which to get the associated <see cref="Style"/> instance</param>
     /// <returns>The <see cref="Style"/> instance associated with the the <see cref="Windows.UI.Xaml.Controls.Pivot"/> or null</returns>
     public static Style GetPivotHeaderItemStyle(Windows.UI.Xaml.Controls.Pivot obj)
-    {
-        return (Style)obj.GetValue(PivotHeaderItemStyleProperty);
-    }
+        => (Style)obj.GetValue(PivotHeaderItemStyleProperty);
 
     /// <summary>
     /// Sets the <see cref="PivotHeaderItem"/> <see cref="Style"/> instance assocaited with the specified <see cref="Windows.UI.Xaml.Controls.Pivot"/>
@@ -31,9 +29,7 @@ public partial class PivotExtensions
     /// <param name="obj">The <see cref="Windows.UI.Xaml.Controls.Pivot"/> to associated the <see cref="Style"/> instance to</param>
     /// <param name="value">The <see cref="Style"/> instance to bind to the <see cref="Windows.UI.Xaml.Controls.Pivot"/></param>
     public static void SetPivotHeaderItemStyle(Windows.UI.Xaml.Controls.Pivot obj, Style value)
-    {
-        obj.SetValue(PivotHeaderItemStyleProperty, value);
-    }
+        => obj.SetValue(PivotHeaderItemStyleProperty, value);
 
     /// <summary>
     /// Attached <see cref="DependencyProperty"/> for binding a <see cref="PivotHeaderItem"/> <see cref="Style"/> as an alternate template to a <see cref="Windows.UI.Xaml.Controls.Pivot"/>
@@ -46,20 +42,14 @@ public partial class PivotExtensions
     /// </summary>
     /// <param name="obj">PivotItem to get value from.</param>
     /// <returns>String value for FontIcon.</returns>
-    public static string GetGlyph(PivotItem obj)
-    {
-        return (string)obj.GetValue(GlyphProperty);
-    }
+    public static string GetGlyph(PivotItem obj) => (string)obj.GetValue(GlyphProperty);
 
     /// <summary>
     /// Sets the attached property value for Glyph.
     /// </summary>
     /// <param name="obj">PivotItem to set value for.</param>
     /// <param name="value">String value for FontIcon.</param>
-    public static void SetGlyph(PivotItem obj, string value)
-    {
-        obj.SetValue(GlyphProperty, value);
-    }
+    public static void SetGlyph(PivotItem obj, string value) => obj.SetValue(GlyphProperty, value);
 
     /// <summary>
     /// Used with the Pivot Styles to specify a FontIcon Glyph using the Segoe MDL2 Assets font.
@@ -72,20 +62,14 @@ public partial class PivotExtensions
     /// </summary>
     /// <param name="obj">PivotItem to get value from.</param>
     /// <returns>Resource to use for an Image in the MSEdgeTabStyle.</returns>
-    public static ImageSource GetImageSource(PivotItem obj)
-    {
-        return (ImageSource)obj.GetValue(ImageSourceProperty);
-    }
+    public static ImageSource GetImageSource(PivotItem obj) => (ImageSource)obj.GetValue(ImageSourceProperty);
 
     /// <summary>
     /// Sets the attached property value for ImageSource.
     /// </summary>
     /// <param name="obj">PivotItem to set value for.</param>
     /// <param name="value">Resource to use for an Image in the MSEdgeTabStyle.</param>
-    public static void SetImageSource(PivotItem obj, ImageSource value)
-    {
-        obj.SetValue(ImageSourceProperty, value);
-    }
+    public static void SetImageSource(PivotItem obj, ImageSource value) => obj.SetValue(ImageSourceProperty, value);
 
     /// <summary>
     /// Used with the Pivot Styles to specify an ImageSource for the MSEdgeTabStyle.
@@ -98,10 +82,8 @@ public partial class PivotExtensions
     /// </summary>
     /// <param name="obj">Pivot to get value from.</param>
     /// <returns>Command value for the MSEdgeTabStyle Close Button.</returns>
-    public static ICommand GetCloseButtonCommand(Windows.UI.Xaml.Controls.Pivot obj) // TODO: Should this be per PivotHeaderItem? Thinking no?
-    {
-        return (ICommand)obj.GetValue(CloseButtonCommandProperty);
-    }
+    public static ICommand GetCloseButtonCommand(Windows.UI.Xaml.Controls.Pivot obj)
+        => (ICommand)obj.GetValue(CloseButtonCommandProperty); // TODO: Should this be per PivotHeaderItem? Thinking no?
 
     /// <summary>
     /// Sets the attached property value for CloseButtonCommand.
@@ -109,9 +91,7 @@ public partial class PivotExtensions
     /// <param name="obj">Pivot to set value for.</param>
     /// <param name="value">Command value for the MSEdgeTabStyle Close Button.</param>
     public static void SetCloseButtonCommand(Windows.UI.Xaml.Controls.Pivot obj, ICommand value)
-    {
-        obj.SetValue(CloseButtonCommandProperty, value);
-    }
+        => obj.SetValue(CloseButtonCommandProperty, value);
 
     /// <summary>
     /// Used with the MSEdgeTab Pivot Styles to specify a Close Command for the Tab's Close Button.
@@ -124,20 +104,14 @@ public partial class PivotExtensions
     /// </summary>
     /// <param name="obj">Pivot to get value from.</param>
     /// <returns>False is content will be hidden.</returns>
-    public static bool GetIsContentVisible(Windows.UI.Xaml.Controls.Pivot obj)
-    {
-        return (bool)obj.GetValue(IsContentVisibleProperty);
-    }
+    public static bool GetIsContentVisible(Windows.UI.Xaml.Controls.Pivot obj) => (bool)obj.GetValue(IsContentVisibleProperty);
 
     /// <summary>
     /// Sets the attached property value for IsContentVisible.
     /// </summary>
     /// <param name="obj">Pivot to set value for.</param>
     /// <param name="value">Set to false to hide the PivotItemsPresenter.</param>
-    public static void SetIsContentVisible(Windows.UI.Xaml.Controls.Pivot obj, bool value)
-    {
-        obj.SetValue(IsContentVisibleProperty, value);
-    }
+    public static void SetIsContentVisible(Windows.UI.Xaml.Controls.Pivot obj, bool value) => obj.SetValue(IsContentVisibleProperty, value);
 
     /// <summary>
     /// Used to hide the content of a Pivot to just use the Pivot Header Items.

--- a/Microsoft.Toolkit.Future/Extensions/SymbolIcon/SymbolIconExtensions.cs
+++ b/Microsoft.Toolkit.Future/Extensions/SymbolIcon/SymbolIconExtensions.cs
@@ -14,15 +14,9 @@ namespace CommunityToolkit.WinUI.Extensions.Future;
 [Bindable]
 public class SymbolIconExtensions
 {
-    public static double GetFontSize(SymbolIcon obj)
-    {
-        return (double)obj.GetValue(FontSizeProperty);
-    }
+    public static double GetFontSize(SymbolIcon obj) => (double)obj.GetValue(FontSizeProperty);
 
-    public static void SetFontSize(SymbolIcon obj, double value)
-    {
-        obj.SetValue(FontSizeProperty, value);
-    }
+    public static void SetFontSize(SymbolIcon obj, double value) => obj.SetValue(FontSizeProperty, value);
 
     // Using a DependencyProperty as the backing store for FontSize.  This enables animation, styling, binding, etc...
     public static readonly DependencyProperty FontSizeProperty =

--- a/XamlStudio.Toolkit.UnitTests/UnitTestApp.xaml.cs
+++ b/XamlStudio.Toolkit.UnitTests/UnitTestApp.xaml.cs
@@ -34,17 +34,13 @@ sealed partial class App : Application
     }
 
     // Abstract CoreApplication.MainView.DispatcherQueue
-    public static DispatcherQueue DispatcherQueue
-    {
-        get
-        {
+    public static DispatcherQueue DispatcherQueue =>
 #if !WINAPPSDK
-            return CoreApplication.MainView.DispatcherQueue;
+            CoreApplication.MainView.DispatcherQueue;
 #else
-            return currentWindow.DispatcherQueue;
+            currentWindow.DispatcherQueue;
 #endif
-        }
-    }
+
 
     /// <summary>
     /// Initializes the singleton application object.  This is the first line of authored code
@@ -101,10 +97,7 @@ sealed partial class App : Application
     /// </summary>
     /// <param name="sender">The Frame which failed navigation</param>
     /// <param name="e">Details about the navigation failure</param>
-    void OnNavigationFailed(object sender, NavigationFailedEventArgs e)
-    {
-        throw new Exception("Failed to load Page " + e.SourcePageType.FullName);
-    }
+    void OnNavigationFailed(object sender, NavigationFailedEventArgs e) => throw new Exception("Failed to load Page " + e.SourcePageType.FullName);
 
     /// <summary>
     /// Invoked when application execution is being suspended.  Application state is saved

--- a/XamlStudio.Toolkit.UnitTests/XmlToXamlTreeTests.cs
+++ b/XamlStudio.Toolkit.UnitTests/XmlToXamlTreeTests.cs
@@ -23,465 +23,451 @@ public class XmlToXamlTreeTests : VisualUITestBase
 {
     [TestMethod]
     public async Task Basic_XmlToXamlTest()
-    {
-        await EnqueueAsync(async () =>
-        {
-            var xaml =
-                """
-                <Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"              
-                      x:Name="ToolboxPage">
-
-                    <Page.Resources>
-                        <Style x:Key="ListViewItemContainerWideStyle" TargetType="ListViewItem">
-                            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                        </Style>
-                    </Page.Resources>
-
-                    <Grid x:Name="RootGrid">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="54" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="*" />
-                        </Grid.RowDefinitions>
-                        <Button Content="First"
-                                Margin="4"/>
-                        <Button>
-                            <TextBlock Text="Second"/>
-                        </Button>
-                    </Grid>
-                </Page>
-                """;
-
-            var fwe = XamlReader.Load(xaml) as FrameworkElement;
-            var xml = Parser.ParseText(xaml);
-
-            await LoadTestContentAsync(fwe);
-
-            XamlXmlTreeCoordinator coordinator = new();
-            coordinator.Initialize(xml, fwe);
-
-            var grid = fwe.FindChild("RootGrid");
-            Assert.IsTrue(coordinator.TryGetXmlElement(grid, out var gridNode));
-            if (gridNode is IXmlElementSyntax gridElement)
+        => await EnqueueAsync(async () =>
             {
-                Assert.AreEqual("RootGrid", gridElement.GetAttributeValue("Name", "x"));
-            }
-            else
-            {
-                Assert.Fail("Xml Node not an Element for Grid");
-            }
+                var xaml =
+                    """
+                    <Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"              
+                          x:Name="ToolboxPage">
 
-            var textblockNode = xml.FindNode(xaml.IndexOf("<TextBlock") + 1).ParentElement;
-            if (textblockNode is IXmlElementSyntax textblockElement)
-            {
-                Assert.IsTrue(coordinator.TryGetVisualElement(textblockElement, out var dotbe));
-                if (dotbe is TextBlock textblock)
+                        <Page.Resources>
+                            <Style x:Key="ListViewItemContainerWideStyle" TargetType="ListViewItem">
+                                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                            </Style>
+                        </Page.Resources>
+
+                        <Grid x:Name="RootGrid">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="54" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+                            <Button Content="First"
+                                    Margin="4"/>
+                            <Button>
+                                <TextBlock Text="Second"/>
+                            </Button>
+                        </Grid>
+                    </Page>
+                    """;
+
+                var fwe = XamlReader.Load(xaml) as FrameworkElement;
+                var xml = Parser.ParseText(xaml);
+
+                await LoadTestContentAsync(fwe);
+
+                XamlXmlTreeCoordinator coordinator = new();
+                coordinator.Initialize(xml, fwe);
+
+                var grid = fwe.FindChild("RootGrid");
+                Assert.IsTrue(coordinator.TryGetXmlElement(grid, out var gridNode));
+                if (gridNode is IXmlElementSyntax gridElement)
                 {
-                    Assert.AreEqual("Second", textblock.Text);
+                    Assert.AreEqual("RootGrid", gridElement.GetAttributeValue("Name", "x"));
                 }
                 else
                 {
-                    Assert.Fail("Failed to retrieve TextBlock from Xml Element");
+                    Assert.Fail("Xml Node not an Element for Grid");
                 }
-            }
-            else
-            {
-                Assert.Fail("Xml Node not an Element for TextBlock");
-            }
 
-            Assert.AreEqual(5, coordinator.Count, "Expected 5 elements to be mapped.");
+                var textblockNode = xml.FindNode(xaml.IndexOf("<TextBlock") + 1).ParentElement;
+                if (textblockNode is IXmlElementSyntax textblockElement)
+                {
+                    Assert.IsTrue(coordinator.TryGetVisualElement(textblockElement, out var dotbe));
+                    if (dotbe is TextBlock textblock)
+                    {
+                        Assert.AreEqual("Second", textblock.Text);
+                    }
+                    else
+                    {
+                        Assert.Fail("Failed to retrieve TextBlock from Xml Element");
+                    }
+                }
+                else
+                {
+                    Assert.Fail("Xml Node not an Element for TextBlock");
+                }
 
-            await UnloadTestContentAsync(fwe);
-        });
-    }
+                Assert.AreEqual(5, coordinator.Count, "Expected 5 elements to be mapped.");
+
+                await UnloadTestContentAsync(fwe);
+            });
 
     [TestMethod]
     public async Task NestedParentTypes_XmlToXamlTest()
-    {
-        await EnqueueAsync(async () =>
-        {
-            var xaml =
-                """
-                <Page
-                    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:local="using:TestApp"
-                    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                    mc:Ignorable="d"
-                    d:DataContext="{d:DesignData /SampleData/XAMLing.json, Type=local:XamlingInfo}">
+        => await EnqueueAsync(async () =>
+            {
+                var xaml =
+                    """
+                    <Page
+                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                        xmlns:local="using:TestApp"
+                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                        mc:Ignorable="d"
+                        d:DataContext="{d:DesignData /SampleData/XAMLing.json, Type=local:XamlingInfo}">
 
-                    <StackPanel>
-                        <TextBlock FontSize="36">
-                            <Run FontSize="96" Foreground="#FFFC5185">#XAMLing</Run><LineBreak/>
-                            <Run>/ˈzæməlɪŋ/</Run><LineBreak/>
-                            <Run FontStyle="Italic">verb</Run> <Run>[With XAML Studio]</Run><LineBreak/>
-                        </TextBlock>
-                        <ItemsControl ItemsSource="{Binding Items}" Margin="20,-12,0,0">
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate>
-                                    <TextBlock Margin="0,0,0,24" FontSize="24">
-                                        <Run Text="{Binding Index}"/>. <Run Text="{Binding Definition}"/>
-                                    </TextBlock>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
                         <StackPanel>
-                            <Image Source="/Assets/LlamaCircle.png" Width="64" Height="64"/>
-                            <TextBlock Text="- The XAML Llama" VerticalAlignment="Center"/>
+                            <TextBlock FontSize="36">
+                                <Run FontSize="96" Foreground="#FFFC5185">#XAMLing</Run><LineBreak/>
+                                <Run>/ˈzæməlɪŋ/</Run><LineBreak/>
+                                <Run FontStyle="Italic">verb</Run> <Run>[With XAML Studio]</Run><LineBreak/>
+                            </TextBlock>
+                            <ItemsControl ItemsSource="{Binding Items}" Margin="20,-12,0,0">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Margin="0,0,0,24" FontSize="24">
+                                            <Run Text="{Binding Index}"/>. <Run Text="{Binding Definition}"/>
+                                        </TextBlock>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                            <StackPanel>
+                                <Image Source="/Assets/LlamaCircle.png" Width="64" Height="64"/>
+                                <TextBlock Text="- The XAML Llama" VerticalAlignment="Center"/>
+                            </StackPanel>
                         </StackPanel>
-                    </StackPanel>
-                </Page>                
-                """;
+                    </Page>                
+                    """;
 
-            var fwe = XamlReader.Load(xaml) as FrameworkElement;
-            var xml = Parser.ParseText(xaml);
+                var fwe = XamlReader.Load(xaml) as FrameworkElement;
+                var xml = Parser.ParseText(xaml);
 
-            await LoadTestContentAsync(fwe);
+                await LoadTestContentAsync(fwe);
 
-            XamlXmlTreeCoordinator coordinator = new();
-            coordinator.Initialize(xml, fwe);
+                XamlXmlTreeCoordinator coordinator = new();
+                coordinator.Initialize(xml, fwe);
 
-            var sp1Index = xaml.IndexOf("<StackPanel>");
-            var sp1Node = xml.FindNode(sp1Index + 1).ParentElement;
-            var sp2Node = xml.FindNode(xaml.IndexOf("<StackPanel>", sp1Index + 1) + 1).ParentElement;
+                var sp1Index = xaml.IndexOf("<StackPanel>");
+                var sp1Node = xml.FindNode(sp1Index + 1).ParentElement;
+                var sp2Node = xml.FindNode(xaml.IndexOf("<StackPanel>", sp1Index + 1) + 1).ParentElement;
 
-            var sp1 = fwe.FindChild<StackPanel>();
-            Assert.IsTrue(coordinator.TryGetXmlElement(sp1, out var sp1NodeRetrieved), "First StackPanel Xml node wasn't Element");
-            Assert.AreEqual(sp1Node, sp1NodeRetrieved, "First StackPanel XML Element didn't match.");
+                var sp1 = fwe.FindChild<StackPanel>();
+                Assert.IsTrue(coordinator.TryGetXmlElement(sp1, out var sp1NodeRetrieved), "First StackPanel Xml node wasn't Element");
+                Assert.AreEqual(sp1Node, sp1NodeRetrieved, "First StackPanel XML Element didn't match.");
 
-            var sp2 = sp1.FindChild<StackPanel>();
-            Assert.IsTrue(coordinator.TryGetXmlElement(sp2, out var sp2NodeRetrieved), "Second StackPanel Xml node wasn't Element");
-            Assert.AreEqual(sp2Node, sp2NodeRetrieved, "Second StackPanel XML Element didn't match.");
+                var sp2 = sp1.FindChild<StackPanel>();
+                Assert.IsTrue(coordinator.TryGetXmlElement(sp2, out var sp2NodeRetrieved), "Second StackPanel Xml node wasn't Element");
+                Assert.AreEqual(sp2Node, sp2NodeRetrieved, "Second StackPanel XML Element didn't match.");
 
-            Assert.AreEqual(7, coordinator.Count, "Expected 7 elements to be mapped.");
+                Assert.AreEqual(7, coordinator.Count, "Expected 7 elements to be mapped.");
 
-            await UnloadTestContentAsync(fwe);
-        });
-    }
+                await UnloadTestContentAsync(fwe);
+            });
 
     [TestMethod]
     public async Task ColorConversion_XmlToXamlTest()
-    {
-        await EnqueueAsync(async () =>
-        {
-            var xaml =
-                """
-                <Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-
-                    <StackPanel>
-                        <Border Background="Blue"/>
-                        <Border Background="#FFFF0000"/>
-                        <Border Background="#0000FF"/>
-                    </StackPanel>
-                </Page>
-                """;
-
-            var fwe = XamlReader.Load(xaml) as FrameworkElement;
-            var xml = Parser.ParseText(xaml);
-
-            await LoadTestContentAsync(fwe);
-
-            XamlXmlTreeCoordinator coordinator = new();
-            coordinator.Initialize(xml, fwe);
-
-            var sp = fwe.FindChild<StackPanel>();
-            Assert.IsTrue(coordinator.TryGetXmlElement(sp, out var spNode));
-            if (spNode is not IXmlElementSyntax)
+        => await EnqueueAsync(async () =>
             {
-                Assert.Fail("Xml Node not an Element for StackPanel");
-            }
+                var xaml =
+                    """
+                    <Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-            var colorMatches = new[]
-            {
-                Colors.Blue,
-                Color.FromArgb(255, 255, 0, 0),
-                Color.FromArgb(255, 0, 0, 255),
-            };
-            var i = 0;
-            var j = 0;
+                        <StackPanel>
+                            <Border Background="Blue"/>
+                            <Border Background="#FFFF0000"/>
+                            <Border Background="#0000FF"/>
+                        </StackPanel>
+                    </Page>
+                    """;
 
-            Assert.AreEqual(3, sp.Children.Count, "Expected StackPanel to have 3 children");
-            foreach (var child in sp.Children)
-            {
-                i = xaml.IndexOf("<Border", i) + 1;
-                var node = xml.FindNode(i).ParentElement;
-                if (node is IXmlElementSyntax nodeElement)
+                var fwe = XamlReader.Load(xaml) as FrameworkElement;
+                var xml = Parser.ParseText(xaml);
+
+                await LoadTestContentAsync(fwe);
+
+                XamlXmlTreeCoordinator coordinator = new();
+                coordinator.Initialize(xml, fwe);
+
+                var sp = fwe.FindChild<StackPanel>();
+                Assert.IsTrue(coordinator.TryGetXmlElement(sp, out var spNode));
+                if (spNode is not IXmlElementSyntax)
                 {
-                    Assert.IsTrue(coordinator.TryGetVisualElement(nodeElement, out var element));
-                    if (element is Border border
-                        && element == child)
+                    Assert.Fail("Xml Node not an Element for StackPanel");
+                }
+
+                var colorMatches = new[]
+                {
+                    Colors.Blue,
+                    Color.FromArgb(255, 255, 0, 0),
+                    Color.FromArgb(255, 0, 0, 255),
+                };
+                var i = 0;
+                var j = 0;
+
+                Assert.AreEqual(3, sp.Children.Count, "Expected StackPanel to have 3 children");
+                foreach (var child in sp.Children)
+                {
+                    i = xaml.IndexOf("<Border", i) + 1;
+                    var node = xml.FindNode(i).ParentElement;
+                    if (node is IXmlElementSyntax nodeElement)
                     {
-                        Assert.AreEqual(colorMatches[j++], (border.Background as SolidColorBrush).Color, $"Unexpected color for Border[{j - 1}]");
-                    }
-                    else
-                    {
-                        Assert.Fail("Unexpected Child Border element");
+                        Assert.IsTrue(coordinator.TryGetVisualElement(nodeElement, out var element));
+                        if (element is Border border
+                            && element == child)
+                        {
+                            Assert.AreEqual(colorMatches[j++], (border.Background as SolidColorBrush).Color, $"Unexpected color for Border[{j - 1}]");
+                        }
+                        else
+                        {
+                            Assert.Fail("Unexpected Child Border element");
+                        }
                     }
                 }
-            }
 
-            Assert.AreEqual(5, coordinator.Count, "Expected 5 elements to be mapped.");
+                Assert.AreEqual(5, coordinator.Count, "Expected 5 elements to be mapped.");
 
-            await UnloadTestContentAsync(fwe);
-        });
-    }
+                await UnloadTestContentAsync(fwe);
+            });
 
     [TestMethod]
     public async Task ImageConversion_XmlToXamlTest()
-    {
-        await EnqueueAsync(async () =>
-        {
-            var xaml =
-                """
-                <Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+        => await EnqueueAsync(async () =>
+            {
+                var xaml =
+                    """
+                    <Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
                 
-                    <StackPanel>
-                        <Image Source="ms-appx:///Assets/StoreLogo.png"/>
-                        <Image Source="ms-appx:///Assets/SplashScreen.png"/>
-                        <Image Source="/Assets/StoreLogo.png"/>
-                        <Image Source="https://picsum.photos/200/200"/>
-                    </StackPanel>
-                </Page>
-                """;
+                        <StackPanel>
+                            <Image Source="ms-appx:///Assets/StoreLogo.png"/>
+                            <Image Source="ms-appx:///Assets/SplashScreen.png"/>
+                            <Image Source="/Assets/StoreLogo.png"/>
+                            <Image Source="https://picsum.photos/200/200"/>
+                        </StackPanel>
+                    </Page>
+                    """;
 
-            var fwe = XamlReader.Load(xaml) as FrameworkElement;
-            var xml = Parser.ParseText(xaml);
+                var fwe = XamlReader.Load(xaml) as FrameworkElement;
+                var xml = Parser.ParseText(xaml);
 
-            await LoadTestContentAsync(fwe);
+                await LoadTestContentAsync(fwe);
 
-            XamlXmlTreeCoordinator coordinator = new();
-            coordinator.Initialize(xml, fwe);
+                XamlXmlTreeCoordinator coordinator = new();
+                coordinator.Initialize(xml, fwe);
 
-            var sp = fwe.FindChild<StackPanel>();
-            Assert.IsTrue(coordinator.TryGetXmlElement(sp, out var spNode));
-            if (spNode is not IXmlElementSyntax)
-            {
-                Assert.Fail("Xml Node not an Element for StackPanel");
-            }
-
-            var uriMatches = new[]
-            {
-                "ms-appx:///Assets/StoreLogo.png",
-                "ms-appx:///Assets/SplashScreen.png",
-                "ms-resource:///Files/Assets/StoreLogo.png", // Gets converted to ms-resource:// path prepended with /Files by System
-                "https://picsum.photos/200/200",
-            };
-            var i = 0;
-            var j = 0;
-
-            Assert.AreEqual(4, sp.Children.Count, "Expected StackPanel to have 3 children");
-            foreach (var child in sp.Children)
-            {
-                i = xaml.IndexOf("<Image", i) + 1;
-                var node = xml.FindNode(i).ParentElement;
-                if (node is IXmlElementSyntax nodeElement)
+                var sp = fwe.FindChild<StackPanel>();
+                Assert.IsTrue(coordinator.TryGetXmlElement(sp, out var spNode));
+                if (spNode is not IXmlElementSyntax)
                 {
-                    Assert.IsTrue(coordinator.TryGetVisualElement(nodeElement, out var element));
-                    if (element is Image image
-                        && element == child)
+                    Assert.Fail("Xml Node not an Element for StackPanel");
+                }
+
+                var uriMatches = new[]
+                {
+                    "ms-appx:///Assets/StoreLogo.png",
+                    "ms-appx:///Assets/SplashScreen.png",
+                    "ms-resource:///Files/Assets/StoreLogo.png", // Gets converted to ms-resource:// path prepended with /Files by System
+                    "https://picsum.photos/200/200",
+                };
+                var i = 0;
+                var j = 0;
+
+                Assert.AreEqual(4, sp.Children.Count, "Expected StackPanel to have 3 children");
+                foreach (var child in sp.Children)
+                {
+                    i = xaml.IndexOf("<Image", i) + 1;
+                    var node = xml.FindNode(i).ParentElement;
+                    if (node is IXmlElementSyntax nodeElement)
                     {
-                        Assert.AreEqual(uriMatches[j++], (image.Source as BitmapImage).UriSource.AbsoluteUri, $"Unexpected uri for Image[{j - 1}]");
-                    }
-                    else
-                    {
-                        Assert.Fail("Unexpected Child Image element");
+                        Assert.IsTrue(coordinator.TryGetVisualElement(nodeElement, out var element));
+                        if (element is Image image
+                            && element == child)
+                        {
+                            Assert.AreEqual(uriMatches[j++], (image.Source as BitmapImage).UriSource.AbsoluteUri, $"Unexpected uri for Image[{j - 1}]");
+                        }
+                        else
+                        {
+                            Assert.Fail("Unexpected Child Image element");
+                        }
                     }
                 }
-            }
 
-            Assert.AreEqual(6, coordinator.Count, "Expected 5 elements to be mapped.");
+                Assert.AreEqual(6, coordinator.Count, "Expected 5 elements to be mapped.");
 
-            await UnloadTestContentAsync(fwe);
-        });
-    }
+                await UnloadTestContentAsync(fwe);
+            });
 
     [TestMethod]
     public async Task NamespacedControl_XmlToXamlTest()
-    {
-        await EnqueueAsync(async () =>
-        {
-            var xaml =
-                """
-                <Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                      xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
-                      x:Name="ToolboxPage">
-
-                    <muxc:TabView x:Name="MyTabView">
-                        <muxc:TabViewItem Header="Tab 1">
-                            <TextBlock Text="Content for Tab 1"/>
-                        </muxc:TabViewItem>
-                        <muxc:TabViewItem Header="Tab 2">
-                            <TextBlock Text="Content for Tab 2"/>
-                        </muxc:TabViewItem>
-                    </muxc:TabView>
-                </Page>
-                """;
-
-            var fwe = XamlReader.Load(xaml) as FrameworkElement;
-            var xml = Parser.ParseText(xaml);
-
-            await LoadTestContentAsync(fwe);
-
-            XamlXmlTreeCoordinator coordinator = new();
-            coordinator.Initialize(xml, fwe);
-
-            var tabview = fwe.FindChild("MyTabView");
-            Assert.IsTrue(coordinator.TryGetXmlElement(tabview, out var tabviewNode));
-            if (tabviewNode is IXmlElementSyntax tabviewElement)
+        => await EnqueueAsync(async () =>
             {
-                Assert.AreEqual("MyTabView", tabviewElement.GetAttributeValue("Name", "x"));
-            }
-            else
-            {
-                Assert.Fail("Xml Node not an Element for TabView");
-            }
+                var xaml =
+                    """
+                    <Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                          xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+                          x:Name="ToolboxPage">
 
-            var tabviewitemNode = xml.FindNode(xaml.IndexOf("<muxc:TabViewItem") + 1).ParentElement;
-            if (tabviewitemNode is IXmlElementSyntax tabviewitemElement)
-            {
-                Assert.IsTrue(coordinator.TryGetVisualElement(tabviewitemElement, out var dotbe));
-                if (dotbe is TabViewItem tabViewItem)
+                        <muxc:TabView x:Name="MyTabView">
+                            <muxc:TabViewItem Header="Tab 1">
+                                <TextBlock Text="Content for Tab 1"/>
+                            </muxc:TabViewItem>
+                            <muxc:TabViewItem Header="Tab 2">
+                                <TextBlock Text="Content for Tab 2"/>
+                            </muxc:TabViewItem>
+                        </muxc:TabView>
+                    </Page>
+                    """;
+
+                var fwe = XamlReader.Load(xaml) as FrameworkElement;
+                var xml = Parser.ParseText(xaml);
+
+                await LoadTestContentAsync(fwe);
+
+                XamlXmlTreeCoordinator coordinator = new();
+                coordinator.Initialize(xml, fwe);
+
+                var tabview = fwe.FindChild("MyTabView");
+                Assert.IsTrue(coordinator.TryGetXmlElement(tabview, out var tabviewNode));
+                if (tabviewNode is IXmlElementSyntax tabviewElement)
                 {
-                    Assert.AreEqual("Tab 1", tabViewItem.Header);
+                    Assert.AreEqual("MyTabView", tabviewElement.GetAttributeValue("Name", "x"));
                 }
                 else
                 {
-                    Assert.Fail("Failed to retrieve TabViewItem from Xml Element");
+                    Assert.Fail("Xml Node not an Element for TabView");
                 }
-            }
-            else
-            {
-                Assert.Fail("Xml Node not an Element for TabViewItem");
-            }
 
-            Assert.AreEqual(6, coordinator.Count, "Expected 6 elements to be mapped.");
+                var tabviewitemNode = xml.FindNode(xaml.IndexOf("<muxc:TabViewItem") + 1).ParentElement;
+                if (tabviewitemNode is IXmlElementSyntax tabviewitemElement)
+                {
+                    Assert.IsTrue(coordinator.TryGetVisualElement(tabviewitemElement, out var dotbe));
+                    if (dotbe is TabViewItem tabViewItem)
+                    {
+                        Assert.AreEqual("Tab 1", tabViewItem.Header);
+                    }
+                    else
+                    {
+                        Assert.Fail("Failed to retrieve TabViewItem from Xml Element");
+                    }
+                }
+                else
+                {
+                    Assert.Fail("Xml Node not an Element for TabViewItem");
+                }
 
-            await UnloadTestContentAsync(fwe);
-        });
-    }
+                Assert.AreEqual(6, coordinator.Count, "Expected 6 elements to be mapped.");
+
+                await UnloadTestContentAsync(fwe);
+            });
 
     [TestMethod]
     public async Task ListViewSimple_XmlToXamlTest()
-    {
-        await EnqueueAsync(async () =>
-        {
-            var xaml =
-                """
-                <Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                      xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
-                      x:Name="ToolboxPage">
-
-                    <ListView x:Name="MyListView">
-                        <ListViewItem>
-                            <TextBlock Text="Content for Item 1"/>
-                        </ListViewItem>
-                    </ListView>
-                </Page>
-                """;
-
-            var fwe = XamlReader.Load(xaml) as FrameworkElement;
-            var xml = Parser.ParseText(xaml);
-
-            await LoadTestContentAsync(fwe);
-
-            XamlXmlTreeCoordinator coordinator = new();
-            coordinator.Initialize(xml, fwe);
-
-            var listview = fwe.FindChild("MyListView");
-            Assert.IsTrue(coordinator.TryGetXmlElement(listview, out var listviewNode));
-            if (listviewNode is IXmlElementSyntax listviewElement)
+        => await EnqueueAsync(async () =>
             {
-                Assert.AreEqual("MyListView", listviewElement.GetAttributeValue("Name", "x"));
-            }
-            else
-            {
-                Assert.Fail("Xml Node not an Element for ListView");
-            }
+                var xaml =
+                    """
+                    <Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                          xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+                          x:Name="ToolboxPage">
 
-            Assert.AreEqual(4, coordinator.Count, "Expected 4 elements to be mapped.");
+                        <ListView x:Name="MyListView">
+                            <ListViewItem>
+                                <TextBlock Text="Content for Item 1"/>
+                            </ListViewItem>
+                        </ListView>
+                    </Page>
+                    """;
 
-            await UnloadTestContentAsync(fwe);
-        });
-    }
+                var fwe = XamlReader.Load(xaml) as FrameworkElement;
+                var xml = Parser.ParseText(xaml);
+
+                await LoadTestContentAsync(fwe);
+
+                XamlXmlTreeCoordinator coordinator = new();
+                coordinator.Initialize(xml, fwe);
+
+                var listview = fwe.FindChild("MyListView");
+                Assert.IsTrue(coordinator.TryGetXmlElement(listview, out var listviewNode));
+                if (listviewNode is IXmlElementSyntax listviewElement)
+                {
+                    Assert.AreEqual("MyListView", listviewElement.GetAttributeValue("Name", "x"));
+                }
+                else
+                {
+                    Assert.Fail("Xml Node not an Element for ListView");
+                }
+
+                Assert.AreEqual(4, coordinator.Count, "Expected 4 elements to be mapped.");
+
+                await UnloadTestContentAsync(fwe);
+            });
 
     [TestMethod]
     public async Task ListViewComplex_XmlToXamlTest()
-    {
-        await EnqueueAsync(async () =>
-        {
-            var xaml =
-                """
-                <Page
-                    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
-                    mc:Ignorable="d"
-                    d:DesignWidth="400"
-                    d:DesignHeight="420">
-
-                    <Page.Resources>
-                        <converters:StringFormatConverter x:Key="StringFormatConverter"/>
-                        <DataTemplate x:Key="PhotoTemplate">
-                            <Grid Background="{Binding Color}"
-                                  Margin="0">
-                                <TextBlock Text="{Binding Word}" FontSize="{Binding Size}" Foreground="Black"/>
-                            </Grid>
-                        </DataTemplate>
-                        <Style TargetType="ListViewItem">
-                            <!--  Change those values to change the WrapPanel's children alignment  -->
-                            <Setter Property="VerticalContentAlignment" Value="Center" />
-                            <Setter Property="HorizontalContentAlignment" Value="Center" />
-                            <Setter Property="Margin" Value="0" />
-                            <Setter Property="Padding" Value="0" />
-                            <Setter Property="MinWidth" Value="0" />
-                            <Setter Property="MinHeight" Value="0" />
-                        </Style>
-                    </Page.Resources>
-
-                    <ListView x:Name="MyListView"
-                              ItemTemplate="{StaticResource PhotoTemplate}"
-                              ItemsSource="{Binding WrapPanelCollection, Mode=OneWay}">
-                        <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <StackPanel x:Name="sampleStackPanel"
-                                            Padding="12"
-                                            Spacing="4" />
-                            </ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                    </ListView>
-                </Page>
-                """;
-
-            var fwe = XamlReader.Load(xaml) as FrameworkElement;
-            var xml = Parser.ParseText(xaml);
-
-            await LoadTestContentAsync(fwe);
-
-            XamlXmlTreeCoordinator coordinator = new();
-            coordinator.Initialize(xml, fwe);
-
-            var listview = fwe.FindChild("MyListView");
-            Assert.IsTrue(coordinator.TryGetXmlElement(listview, out var listviewNode));
-            if (listviewNode is IXmlElementSyntax listviewElement)
+        => await EnqueueAsync(async () =>
             {
-                Assert.AreEqual("MyListView", listviewElement.GetAttributeValue("Name", "x"));
-            }
-            else
-            {
-                Assert.Fail("Xml Node not an Element for ListView");
-            }
+                var xaml =
+                    """
+                    <Page
+                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                        xmlns:converters="using:CommunityToolkit.WinUI.Converters"
+                        mc:Ignorable="d"
+                        d:DesignWidth="400"
+                        d:DesignHeight="420">
 
-            Assert.AreEqual(2, coordinator.Count, "Expected 2 elements to be mapped.");
+                        <Page.Resources>
+                            <converters:StringFormatConverter x:Key="StringFormatConverter"/>
+                            <DataTemplate x:Key="PhotoTemplate">
+                                <Grid Background="{Binding Color}"
+                                      Margin="0">
+                                    <TextBlock Text="{Binding Word}" FontSize="{Binding Size}" Foreground="Black"/>
+                                </Grid>
+                            </DataTemplate>
+                            <Style TargetType="ListViewItem">
+                                <!--  Change those values to change the WrapPanel's children alignment  -->
+                                <Setter Property="VerticalContentAlignment" Value="Center" />
+                                <Setter Property="HorizontalContentAlignment" Value="Center" />
+                                <Setter Property="Margin" Value="0" />
+                                <Setter Property="Padding" Value="0" />
+                                <Setter Property="MinWidth" Value="0" />
+                                <Setter Property="MinHeight" Value="0" />
+                            </Style>
+                        </Page.Resources>
 
-            await UnloadTestContentAsync(fwe);
-        });
-    }
+                        <ListView x:Name="MyListView"
+                                  ItemTemplate="{StaticResource PhotoTemplate}"
+                                  ItemsSource="{Binding WrapPanelCollection, Mode=OneWay}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <StackPanel x:Name="sampleStackPanel"
+                                                Padding="12"
+                                                Spacing="4" />
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                        </ListView>
+                    </Page>
+                    """;
+
+                var fwe = XamlReader.Load(xaml) as FrameworkElement;
+                var xml = Parser.ParseText(xaml);
+
+                await LoadTestContentAsync(fwe);
+
+                XamlXmlTreeCoordinator coordinator = new();
+                coordinator.Initialize(xml, fwe);
+
+                var listview = fwe.FindChild("MyListView");
+                Assert.IsTrue(coordinator.TryGetXmlElement(listview, out var listviewNode));
+                if (listviewNode is IXmlElementSyntax listviewElement)
+                {
+                    Assert.AreEqual("MyListView", listviewElement.GetAttributeValue("Name", "x"));
+                }
+                else
+                {
+                    Assert.Fail("Xml Node not an Element for ListView");
+                }
+
+                Assert.AreEqual(2, coordinator.Count, "Expected 2 elements to be mapped.");
+
+                await UnloadTestContentAsync(fwe);
+            });
 }

--- a/XamlStudio.Toolkit/Controls/ResourceViewer/Helpers/ColorToHexConverter.cs
+++ b/XamlStudio.Toolkit/Controls/ResourceViewer/Helpers/ColorToHexConverter.cs
@@ -22,8 +22,5 @@ public class ColorToHexConverter : IValueConverter
         return value;
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, string language)
-    {
-        throw new NotImplementedException();
-    }
+    public object ConvertBack(object value, Type targetType, object parameter, string language) => throw new NotImplementedException();
 }

--- a/XamlStudio.Toolkit/Controls/ResourceViewer/TemplateSelector.cs
+++ b/XamlStudio.Toolkit/Controls/ResourceViewer/TemplateSelector.cs
@@ -21,15 +21,9 @@ public class TemplateSelector : DataTemplateSelector
     {
     }
 
-    protected override DataTemplate SelectTemplateCore(object item)
-    {
-        return LookupDataTemplate(item);
-    }
+    protected override DataTemplate SelectTemplateCore(object item) => LookupDataTemplate(item);
 
-    protected override DataTemplate SelectTemplateCore(object item, DependencyObject container)
-    {
-        return LookupDataTemplate(item);
-    }
+    protected override DataTemplate SelectTemplateCore(object item, DependencyObject container) => LookupDataTemplate(item);
 
     private DataTemplate LookupDataTemplate(object item)
     {

--- a/XamlStudio.Toolkit/Converters/ColorToNameConverter.cs
+++ b/XamlStudio.Toolkit/Converters/ColorToNameConverter.cs
@@ -40,8 +40,5 @@ public class ColorToNameConverter : IValueConverter
         return null;
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, string language)
-    {
-        throw new NotImplementedException();
-    }
+    public object ConvertBack(object value, Type targetType, object parameter, string language) => throw new NotImplementedException();
 }

--- a/XamlStudio.Toolkit/Converters/HexToColorConverter.cs
+++ b/XamlStudio.Toolkit/Converters/HexToColorConverter.cs
@@ -55,8 +55,5 @@ public class HexToColorConverter : IValueConverter
         return null;
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, string language)
-    {
-        return Convert(value, targetType, parameter, language);
-    }
+    public object ConvertBack(object value, Type targetType, object parameter, string language) => Convert(value, targetType, parameter, language);
 }

--- a/XamlStudio.Toolkit/Converters/StringToUriConverter.cs
+++ b/XamlStudio.Toolkit/Converters/StringToUriConverter.cs
@@ -14,9 +14,8 @@ public sealed class StringToUriConverter : IValueConverter
     {
         if (value is string)
         {
-            Uri result;
 
-            if (Uri.TryCreate(value as string, UriKind.RelativeOrAbsolute, out result))
+            if (Uri.TryCreate(value as string, UriKind.RelativeOrAbsolute, out var result))
             {
                 return result;
             }
@@ -25,8 +24,5 @@ public sealed class StringToUriConverter : IValueConverter
         return null;
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, string language)
-    {
-        throw new NotImplementedException();
-    }
+    public object ConvertBack(object value, Type targetType, object parameter, string language) => throw new NotImplementedException();
 }

--- a/XamlStudio.Toolkit/Extensions/XmlExtensions.cs
+++ b/XamlStudio.Toolkit/Extensions/XmlExtensions.cs
@@ -11,10 +11,7 @@ namespace XamlStudio.Toolkit.Extensions;
 
 public static class XmlExtensions
 {
-    public static XAttribute GetNamedItem(this IEnumerable<XAttribute> list, string name)
-    {
-        return list.Where(item => item.Name == name).FirstOrDefault();
-    }
+    public static XAttribute GetNamedItem(this IEnumerable<XAttribute> list, string name) => list.Where(item => item.Name == name).FirstOrDefault();
 
     public static IEnumerable<XmlNode> GetTypedEnumerator(this XmlNodeList list)
     {

--- a/XamlStudio.Toolkit/Helpers/Singleton.cs
+++ b/XamlStudio.Toolkit/Helpers/Singleton.cs
@@ -14,13 +14,7 @@ namespace XamlStudio.Toolkit.Helpers;
 public static class Singleton<T>
     where T : new()
 {
-    private static ConcurrentDictionary<Type, T> _instances = new ConcurrentDictionary<Type, T>();
+    private static ConcurrentDictionary<Type, T> _instances = new();
 
-    public static T Instance
-    {
-        get
-        {
-            return _instances.GetOrAdd(typeof(T), (t) => new T());
-        }
-    }
+    public static T Instance => _instances.GetOrAdd(typeof(T), (t) => new T());
 }

--- a/XamlStudio.Toolkit/Helpers/VisualStateWatcher.cs
+++ b/XamlStudio.Toolkit/Helpers/VisualStateWatcher.cs
@@ -16,7 +16,7 @@ public class VisualStateWatcher
 
     public VisualStateWatcher(FrameworkElement element)
     {
-        Dictionary<string, VisualStateInfo[]> visualStateGroups = new();
+        Dictionary<string, VisualStateInfo[]> visualStateGroups = [];
 
         // Get child of the control in visual tree as that'll contain the VSM
         // and will be more expected when manipulating a control itself (as that's the element we manipulate).
@@ -33,7 +33,7 @@ public class VisualStateWatcher
                     gname = $"- Unnamed {gindex++} -";
                 }
 
-                List<VisualStateInfo> visualStates = new();
+                List<VisualStateInfo> visualStates = [];
                 foreach (var state in group.States)
                 {
                     visualStates.Add(new VisualStateInfo(state.Name, gname, state == group.CurrentState));

--- a/XamlStudio.Toolkit/Models/ConversionRecord.cs
+++ b/XamlStudio.Toolkit/Models/ConversionRecord.cs
@@ -17,7 +17,7 @@ public class ConversionRecord
 
     public object Result { get; private set; }
 
-    public object ResultOrValue { get { return Result ?? Value; } }
+    public object ResultOrValue => Result ?? Value;
 
     public bool HasResult { get; private set; }
 

--- a/XamlStudio.Toolkit/Models/XamlBindingInfo.cs
+++ b/XamlStudio.Toolkit/Models/XamlBindingInfo.cs
@@ -38,7 +38,7 @@ public class XamlBindingInfo : INotifyPropertyChanged
 
     public uint Line { get; private set; }
     public uint Column { get; private set; }
-    public int Length { get { return this.OriginalBindingString.Length; } }
+    public int Length => this.OriginalBindingString.Length;
 
     public XAttribute PropertyAttribute { get; set; }
     public string PropertyName { get; set; }
@@ -46,7 +46,7 @@ public class XamlBindingInfo : INotifyPropertyChanged
     public string ElementName { get; set; }
 
     // TODO: Create a Binding Log window in Xaml Studio which shows all binding events and lets you group/sort/search by time, value, status (etc...)
-    public ObservableCollection<ConversionRecord> BindingHistory { get; set; } = new ObservableCollection<ConversionRecord>();
+    public ObservableCollection<ConversionRecord> BindingHistory { get; set; } = [];
 
     // TODO: Make Observable?
 
@@ -55,17 +55,17 @@ public class XamlBindingInfo : INotifyPropertyChanged
 
     public XamlRenderService Service { get; internal set; }
 
-    public DateTime FirstSetTime { get { return BindingHistory.Count == 0 ? DateTime.MinValue : BindingHistory.First().TimeStamp; } }
+    public DateTime FirstSetTime => BindingHistory.Count == 0 ? DateTime.MinValue : BindingHistory.First().TimeStamp;
 
-    public DateTime LastConvertedTime { get { return BindingHistory.Count == 0 ? DateTime.MinValue : BindingHistory.Last().TimeStamp; } }
+    public DateTime LastConvertedTime => BindingHistory.Count == 0 ? DateTime.MinValue : BindingHistory.Last().TimeStamp;
 
-    public bool HasBinded { get { return BindingHistory.Count > 0; } }
+    public bool HasBinded => BindingHistory.Count > 0;
 
-    public bool HasConverter { get { return Converter != null; } }
+    public bool HasConverter => Converter != null;
 
-    public object LastConvertedValue { get { return BindingHistory.LastOrDefault()?.Value; } }
+    public object LastConvertedValue => BindingHistory.LastOrDefault()?.Value;
 
-    public object LastConvertedResult { get { return BindingHistory.LastOrDefault()?.Result; } }
+    public object LastConvertedResult => BindingHistory.LastOrDefault()?.Result;
 
     public object LastConvertedResultOrValue
     {
@@ -82,12 +82,9 @@ public class XamlBindingInfo : INotifyPropertyChanged
         }
     }
 
-    public string LastConvertedResultOrValueString
-    {
-        get { return LastConvertedResultOrValue?.ToString() ?? string.Empty; }
-    }
+    public string LastConvertedResultOrValueString => LastConvertedResultOrValue?.ToString() ?? string.Empty;
 
-    public string LastExceptionMessage { get { return BindingHistory.LastOrDefault()?.ExceptionObject.Message; } }
+    public string LastExceptionMessage => BindingHistory.LastOrDefault()?.ExceptionObject.Message;
 
     public XamlBindingState LastKnownBindingState
     {
@@ -106,7 +103,7 @@ public class XamlBindingInfo : INotifyPropertyChanged
         }
     }
 
-    public long BindingCount { get { return BindingHistory.Count; } }
+    public long BindingCount => BindingHistory.Count;
     #endregion
 
     public XamlBindingInfo(uint line, uint column, string binding)

--- a/XamlStudio.Toolkit/Models/XamlRenderResultContext.cs
+++ b/XamlStudio.Toolkit/Models/XamlRenderResultContext.cs
@@ -10,13 +10,16 @@ using Windows.UI.Xaml;
 
 namespace XamlStudio.Toolkit.Models;
 
-public class XamlRenderResultContext
+/// <summary>
+/// Create a new XamlRenderResultContext for the given initial content.
+/// </summary>
+/// <param name="initialContent">Initial string passed to render.</param>
+public class XamlRenderResultContext(string initialContent)
 {
-    private readonly string _content;
     /// <summary>
     /// Original Content passed in to the <see cref="Services.XamlRenderService.RenderAsync(string)"/> call.
     /// </summary>
-    public string Content => _content;
+    public string Content { get; } = initialContent;
 
     /// <summary>
     /// Gets a value indicating if the content has a suggestion.
@@ -26,7 +29,7 @@ public class XamlRenderResultContext
     /// <summary>
     /// Content modified by pre-parser helpers with any missing xmlns elements.
     /// </summary>
-    public string SuggestedContent { get; internal set; }
+    public string SuggestedContent { get; internal set; } = initialContent;
 
     /// <summary>
     /// Content that represents the actually rendered <see cref="Element"/>.
@@ -34,7 +37,7 @@ public class XamlRenderResultContext
     /// which add missing elements or inject helpers for images, data context, and binding debugging.
     /// It is mainly intended for debugging the <see cref="Services.XamlRenderService"/> itself.
     /// </summary>
-    public string RenderedContent { get; internal set; }
+    public string RenderedContent { get; internal set; } = initialContent;
 
     /// <summary>
     /// Element rendered by <see cref="Services.XamlRenderService.RenderAsync(string)"/> or null if rendering was unsuccessful.
@@ -99,7 +102,7 @@ public class XamlRenderResultContext
     /// <summary>
     /// Gets the list of Errors found if <see cref="Services.XamlRenderService.RenderAsync(string)"/> was unsuccessful.
     /// </summary>
-    public IList<XamlExceptionRange> Errors { get; internal set; } = new List<XamlExceptionRange>();
+    public IList<XamlExceptionRange> Errors { get; internal set; } = [];
 
     /// <summary>
     /// Gets the list of Bindings found when <see cref="IsBindingDebuggingEnabled"/> is turned on.  Cleared and Populated after a call to <see cref="Services.XamlRenderService.RenderAsync(string)"/>.
@@ -110,15 +113,4 @@ public class XamlRenderResultContext
     /// Gets the list of known Namespaces found on the document.
     /// </summary>
     public XmlnsNamespace[] DetectedNamespaces { get; internal set; }
-
-    /// <summary>
-    /// Create a new XamlRenderResultContext for the given initial content.
-    /// </summary>
-    /// <param name="initialContent">Initial string passed to render.</param>
-    public XamlRenderResultContext(string initialContent)
-    {
-        _content = initialContent;
-        SuggestedContent = initialContent;
-        RenderedContent = initialContent;
-    }
 }

--- a/XamlStudio.Toolkit/Models/XamlRenderSettings.cs
+++ b/XamlStudio.Toolkit/Models/XamlRenderSettings.cs
@@ -12,7 +12,7 @@ namespace XamlStudio.Toolkit.Models;
 /// </summary>
 public class XamlRenderSettings
 {
-    private HashSet<XmlnsNamespace> _namespaces = new HashSet<XmlnsNamespace>();
+    private HashSet<XmlnsNamespace> _namespaces = [];
     /// <summary>
     /// Gets the dictionary of known namespaces to automatically try and add if missing in given content to Render.
     /// </summary>

--- a/XamlStudio.Toolkit/Parsers/BindingParser.cs
+++ b/XamlStudio.Toolkit/Parsers/BindingParser.cs
@@ -24,7 +24,7 @@ public static class BindingParser
 
     // Put together our possible Property = Value clause
     private static string BindingPropertiesPattern = string.Format("({0}\\s*=\\s*{1})+", regProp, regValue);
-    private static Regex BindingPropertyExtractor = new Regex(BindingPropertiesPattern, RegexOptions.Compiled | RegexOptions.Singleline);
+    private static Regex BindingPropertyExtractor = new(BindingPropertiesPattern, RegexOptions.Compiled | RegexOptions.Singleline);
 
     private static Dictionary<string, PropertyInfo> PropertyTable =
         typeof(BindingValue).GetProperties()

--- a/XamlStudio.Toolkit/Services/AppAssemblyInfo.cs
+++ b/XamlStudio.Toolkit/Services/AppAssemblyInfo.cs
@@ -19,7 +19,7 @@ public class AppAssemblyInfo
 {
     public static AppAssemblyInfo Instance => Singleton<AppAssemblyInfo>.Instance;
 
-    private readonly AsyncLock _mutex = new AsyncLock();
+    private readonly AsyncLock _mutex = new();
     public bool IsLoaded { get; private set; }
 
     public IReadOnlyList<Assembly> LoadedAssemblies { get; private set; }
@@ -50,10 +50,11 @@ public class AppAssemblyInfo
         // Add any provided assemblies
         // Current workaround for Microsoft.UI.Xaml and this limitation:
         // https://social.msdn.microsoft.com/Forums/en-US/a78fdd8e-a108-4279-9e6b-6c87cd0a0f0f/assemblyload-of-winmd-file-possible
-        var assemblies = new HashSet<Assembly>(extraAssemblies ?? Enumerable.Empty<Assembly>());
-
-        // Add Windows Assembly
-        assemblies.Add(typeof(FrameworkElement).GetTypeInfo().Assembly); // Windows.UI.Xaml
+        var assemblies = new HashSet<Assembly>(extraAssemblies ?? Enumerable.Empty<Assembly>())
+        {
+            // Add Windows Assembly
+            typeof(FrameworkElement).GetTypeInfo().Assembly // Windows.UI.Xaml
+        };
 
         // Add Other Assemblies (Debug Only)
         var files = await Windows.ApplicationModel.Package.Current.InstalledLocation.GetFilesAsync();
@@ -102,7 +103,7 @@ public class AppAssemblyInfo
             }
             else if (!mapping.ContainsKey(type.Namespace))
             {
-                mapping[type.Namespace] = new List<Type>();
+                mapping[type.Namespace] = [];
             }
 
             mapping[type.Namespace].Add(type);

--- a/XamlStudio.Toolkit/Services/IdGenerator.cs
+++ b/XamlStudio.Toolkit/Services/IdGenerator.cs
@@ -11,7 +11,7 @@ namespace XamlStudio.Toolkit.Services;
 /// </summary>
 public static class IdGenerator
 {
-    public static object lockable = new object();
+    public static object lockable = new();
     public static int _count = 1;
 
     public static int Next()

--- a/XamlStudio.Toolkit/Services/XamlAutocompleteService/XamlAutocompleteService.cs
+++ b/XamlStudio.Toolkit/Services/XamlAutocompleteService/XamlAutocompleteService.cs
@@ -20,7 +20,7 @@ public class XamlAutocompleteService
 
     private const string RegexPattern_XmlnsNamespace = @"xmlns(|:(?<Prefix>[\w-]*))=""(?<Namespace>.*)""";
 
-    private static Regex _namespaceSearcher = new Regex(RegexPattern_XmlnsNamespace, RegexOptions.Compiled);
+    private static Regex _namespaceSearcher = new(RegexPattern_XmlnsNamespace, RegexOptions.Compiled);
 
     public IEnumerable<XmlnsNamespace> GetNamespaces(string content)
     {

--- a/XamlStudio.Toolkit/Services/XamlAutocompleteService/XamlLanguageProvider.cs
+++ b/XamlStudio.Toolkit/Services/XamlAutocompleteService/XamlLanguageProvider.cs
@@ -32,82 +32,77 @@ public class XamlLanguageProvider : CompletionItemProvider
     public string[] TriggerCharacters => new string[] { ElementTrigger, CloseElementTrigger, NamespaceTrigger, AttributeValueTrigger };
 
     public IAsyncOperation<CompletionList> ProvideCompletionItemsAsync(IModel model, IPosition position, CompletionContext context)
-    {
-        return AsyncInfo.Run(async delegate (CancellationToken cancelationToken)
-        {
-            var items = new List<CompletionItem>();
-
-            // get editor content before the pointer
-            var text = await model.GetValueAsync();
-
-            // TODO: Should try and coordinate where we need this model between render, document, and here.
-            // LINK: Document.xaml.cs:UpdateBreadcrumbs
-            var _xmlRoot = Parser.ParseText(text);
-
-            var index = text.GetCharacterIndex((int)position.LineNumber, (int)position.Column);
-
-            if (index == -1)
+        => AsyncInfo.Run(async delegate (CancellationToken cancelationToken)
             {
-                return null;
-            }
+                var items = new List<CompletionItem>();
 
-            var raw_node = _xmlRoot.FindNode(index + 1);
+                // get editor content before the pointer
+                var text = await model.GetValueAsync();
 
-            var parentTagName = raw_node?.ParentElement?.Name;
+                // TODO: Should try and coordinate where we need this model between render, document, and here.
+                // LINK: Document.xaml.cs:UpdateBreadcrumbs
+                var _xmlRoot = Parser.ParseText(text);
 
-            // get list of assemblies
-            var namespaces = KnownNamespaces.Concat(XamlAutocompleteService.Instance.GetNamespaces(await model.GetValueAsync()));
+                var index = text.GetCharacterIndex((int)position.LineNumber, (int)position.Column);
 
-            if (context.TriggerCharacter == CloseElementTrigger)
-            {
-                if (index >= 1 && text[index - 1] == '<')
+                if (index == -1)
                 {
-                    // Only show suggestion if we're starting a close tag.
-                    items.Add(new CompletionItem(parentTagName, CompletionItemKind.Class));
+                    return null;
                 }
-            }
-            else if (context.TriggerCharacter == ElementTrigger)
-            {
-                // TODO: Add hint of containing element (ResourceDictionary, 
-                XamlAutocompleteService.Instance.AddDefaultSuggestions(items, KnownNamespaces);
-            }
-            else if (context.TriggerCharacter == NamespaceTrigger)
-            {
-                // TODO: Don't show these if in first tag... show suggestions from known namespaces list... (not accessible here, in App :()
-                if (!string.IsNullOrWhiteSpace(parentTagName))
+
+                var raw_node = _xmlRoot.FindNode(index + 1);
+
+                var parentTagName = raw_node?.ParentElement?.Name;
+
+                // get list of assemblies
+                var namespaces = KnownNamespaces.Concat(XamlAutocompleteService.Instance.GetNamespaces(await model.GetValueAsync()));
+
+                if (context.TriggerCharacter == CloseElementTrigger)
                 {
-                    XamlAutocompleteService.Instance.AddNamespaceSuggestions(items, parentTagName.Trim(':'), KnownNamespaces);
+                    if (index >= 1 && text[index - 1] == '<')
+                    {
+                        // Only show suggestion if we're starting a close tag.
+                        items.Add(new CompletionItem(parentTagName, CompletionItemKind.Class));
+                    }
                 }
-            }
-            else if (context.TriggerCharacter == AttributeValueTrigger)
-            {
-                if (!string.IsNullOrWhiteSpace(parentTagName))
+                else if (context.TriggerCharacter == ElementTrigger)
                 {
-                    var attribute = raw_node.FirstAncestorOrSelf<XmlAttributeSyntax>();
-
-                    XamlAutocompleteService.Instance.AddValueSuggestions(items, parentTagName, attribute?.Name);
+                    // TODO: Add hint of containing element (ResourceDictionary, 
+                    XamlAutocompleteService.Instance.AddDefaultSuggestions(items, KnownNamespaces);
                 }
-            }
-            else
-            {
-                if (!string.IsNullOrWhiteSpace(parentTagName))
+                else if (context.TriggerCharacter == NamespaceTrigger)
                 {
-                    var attribute = raw_node.FirstAncestorOrSelf<XmlAttributeSyntax>();
-
-                    // TODO: Filter out already used properties...
-                    XamlAutocompleteService.Instance.AddPropertySuggestions(items, parentTagName);
+                    // TODO: Don't show these if in first tag... show suggestions from known namespaces list... (not accessible here, in App :()
+                    if (!string.IsNullOrWhiteSpace(parentTagName))
+                    {
+                        XamlAutocompleteService.Instance.AddNamespaceSuggestions(items, parentTagName.Trim(':'), KnownNamespaces);
+                    }
                 }
-            }
+                else if (context.TriggerCharacter == AttributeValueTrigger)
+                {
+                    if (!string.IsNullOrWhiteSpace(parentTagName))
+                    {
+                        var attribute = raw_node.FirstAncestorOrSelf<XmlAttributeSyntax>();
 
-            return new CompletionList()
-            {
-                Items = items
-            };
-        });
-    }
+                        XamlAutocompleteService.Instance.AddValueSuggestions(items, parentTagName, attribute?.Name);
+                    }
+                }
+                else
+                {
+                    if (!string.IsNullOrWhiteSpace(parentTagName))
+                    {
+                        var attribute = raw_node.FirstAncestorOrSelf<XmlAttributeSyntax>();
 
-    public IAsyncOperation<CompletionItem> ResolveCompletionItemAsync(CompletionItem item)
-    {
-        throw new NotImplementedException();
-    }
+                        // TODO: Filter out already used properties...
+                        XamlAutocompleteService.Instance.AddPropertySuggestions(items, parentTagName);
+                    }
+                }
+
+                return new CompletionList()
+                {
+                    Items = items
+                };
+            });
+
+    public IAsyncOperation<CompletionItem> ResolveCompletionItemAsync(CompletionItem item) => throw new NotImplementedException();
 }

--- a/XamlStudio.Toolkit/Services/XamlBindingWrapperManager.cs
+++ b/XamlStudio.Toolkit/Services/XamlBindingWrapperManager.cs
@@ -14,15 +14,15 @@ namespace XamlStudio.Toolkit.Services;
 /// </summary>
 public class XamlBindingWrapperManager : Dictionary<int, XamlBindingInfo>
 {
-    private readonly Dictionary<int, XamlRenderService> _renderers = new Dictionary<int, XamlRenderService>();
-    private readonly Dictionary<int, List<int>> _tracker = new Dictionary<int, List<int>>();
+    private readonly Dictionary<int, XamlRenderService> _renderers = [];
+    private readonly Dictionary<int, List<int>> _tracker = [];
 
     public static XamlBindingWrapperManager Instance => Singleton<XamlBindingWrapperManager>.Instance;
 
     public void Register(int id, XamlRenderService service)
     {
         this._renderers.Add(id, service);
-        this._tracker[id] = new List<int>();
+        this._tracker[id] = [];
     }
 
     public void AddNewBinding(int serviceId, XamlBindingInfo binding)
@@ -51,6 +51,6 @@ public class XamlBindingWrapperManager : Dictionary<int, XamlBindingInfo>
             this.Remove(binding);
         }
 
-        this._tracker[serviceId] = new List<int>();
+        this._tracker[serviceId] = [];
     }
 }

--- a/XamlStudio.Toolkit/Services/XamlRenderService/XamlRenderService.ParseBinding.cs
+++ b/XamlStudio.Toolkit/Services/XamlRenderService/XamlRenderService.ParseBinding.cs
@@ -14,8 +14,8 @@ public partial class XamlRenderService
 {
     private const string BindingSearcherPattern = "([\"']){\\s*(?<Type>(?:Binding)).*?}\\1"; //"([\"']){\\s*(?<Type>(?:Binding)|(?:x:Bind)).*?}\\1"; // \1 matches initial single or double quote used in first capturing group.
     private const string BindingPropertiesPattern = "((?<Property>(?:BindBack)|(?:Converter)|(?:ConverterLanguage)|(?:ConverterParameter)|(?:ElementName)|(?:FallbackValue)|(?:Mode)|(?:Path)|(?:RelativeSource)|(?:Source)|(?:TargetNullValue)|(?:UpdateSourceTrigger))\\s*=\\s*(?<Value>.*?(?({)({(?>{(?<DEPTH>)|}(?<-DEPTH>)|.?)*(?(DEPTH)(?!))}(?=[,}]))|(.*?(?=[,}])))))+";
-    private static Regex BindingSearcher = new Regex(BindingSearcherPattern, RegexOptions.Compiled | RegexOptions.Singleline);
-    private static Regex BindingPropertyExtractor = new Regex(BindingPropertiesPattern, RegexOptions.Compiled | RegexOptions.Singleline);
+    private static Regex BindingSearcher = new(BindingSearcherPattern, RegexOptions.Compiled | RegexOptions.Singleline);
+    private static Regex BindingPropertyExtractor = new(BindingPropertiesPattern, RegexOptions.Compiled | RegexOptions.Singleline);
 
     /// <summary>
     /// Replace Binding Expressions with equivalents but intercepted by our own converter for additional logic/redirection.

--- a/XamlStudio.Toolkit/Services/XamlRenderService/XamlRenderService.ParsePre.cs
+++ b/XamlStudio.Toolkit/Services/XamlRenderService/XamlRenderService.ParsePre.cs
@@ -20,8 +20,8 @@ public partial class XamlRenderService
     private const string RegexPattern_FirstTagAfterComment = @"(?!(<\?|<!))*<[^<!\?]*?>";
     private const string RegexPattern_ElementName = "<((?<Prefix>\\w+):)?(?<Type>\\w+)";
 
-    private static Regex _initialTagSearcher = new Regex(RegexPattern_FirstTagAfterComment, RegexOptions.Compiled);
-    private static Regex _elementNameSearcher = new Regex(RegexPattern_ElementName, RegexOptions.Compiled);
+    private static Regex _initialTagSearcher = new(RegexPattern_FirstTagAfterComment, RegexOptions.Compiled);
+    private static Regex _elementNameSearcher = new(RegexPattern_ElementName, RegexOptions.Compiled);
 
     /// <summary>
     /// Returns the first initial element tag after a comment.
@@ -147,11 +147,9 @@ public partial class XamlRenderService
         context.RenderedContent = content;
     }
 
-    public static Type GetTypeFromName(string typename)
-    {
+    public static Type GetTypeFromName(string typename) =>
         // TODO: Do we need to worry about conflicting names across assemblies and pass in the namespace to this function?
-        return AppAssemblyInfo.Instance.KnownTypes.FirstOrDefault(t => t.Name == typename);
-    }
+        AppAssemblyInfo.Instance.KnownTypes.FirstOrDefault(t => t.Name == typename);
 
     internal static bool IsFrameworkElement(Type type)
     {

--- a/XamlStudio.Toolkit/Services/XamlRenderService/XamlRenderService.cs
+++ b/XamlStudio.Toolkit/Services/XamlRenderService/XamlRenderService.cs
@@ -39,17 +39,13 @@ public partial class XamlRenderService
     public async Task<XamlRenderResultContext> RenderAsync(string content, XamlRenderSettings settings = null)
     {
         // Use default settings if none provided.
-        if (settings == null)
-        {
-            settings = new XamlRenderSettings();
-        }
+        settings ??= new XamlRenderSettings();
 
         // Remove previous Binding Tracking
         XamlBindingWrapperManager.Instance.Clear(this.Id);
 
         // Hold all outcomes of this process in an object we'll return when done.
-        var result = new XamlRenderResultContext(content);
-        result.Bindings = Enumerable.Empty<XamlBindingInfo>();
+        var result = new XamlRenderResultContext(content) { Bindings = Enumerable.Empty<XamlBindingInfo>() };
 
         // Load extra Metadata about other available types.
         if (!AppAssemblyInfo.Instance.IsLoaded)
@@ -231,10 +227,7 @@ public partial class XamlRenderService
                                 // Merge App.xaml resources into our root element's resources.
                                 if (result.Element is FrameworkElement rootFwe)
                                 {
-                                    if (rootFwe.Resources == null)
-                                    {
-                                        rootFwe.Resources = new ResourceDictionary();
-                                    }
+                                    rootFwe.Resources ??= [];
                                     // Note: This needs to happen before element is added to the Visual Tree!
                                     // IMPORTANT!!! This doesn't work for all styling (weirdly) while under a debugger... need to file a WinUI bug...
                                     rootFwe.Resources.MergedDictionaries.Add(appResources);

--- a/XamlStudio.Toolkit/Services/XamlXmlTreeCoordinator.cs
+++ b/XamlStudio.Toolkit/Services/XamlXmlTreeCoordinator.cs
@@ -274,7 +274,7 @@ public class XamlXmlTreeCoordinator
         }
     };
 
-    private BidirectionalDictionary<IXmlElementSyntax, DependencyObject> _treeMapper = new();
+    private BidirectionalDictionary<IXmlElementSyntax, DependencyObject> _treeMapper = [];
 
     public int Count => _treeMapper.Count;
 
@@ -286,15 +286,9 @@ public class XamlXmlTreeCoordinator
 
     public IReadOnlyCollection<IXmlElementSyntax> GetXmlElements() => _treeMapper.Keys;
 
-    public bool TryGetVisualElement(IXmlElementSyntax node, out DependencyObject element)
-    {
-        return _treeMapper.TryGetValue(node, out element);
-    }
+    public bool TryGetVisualElement(IXmlElementSyntax node, out DependencyObject element) => _treeMapper.TryGetValue(node, out element);
 
-    public bool TryGetXmlElement(DependencyObject element, out IXmlElementSyntax node)
-    {
-        return _treeMapper.Inverse.TryGetValue(element, out node);
-    }
+    public bool TryGetXmlElement(DependencyObject element, out IXmlElementSyntax node) => _treeMapper.Inverse.TryGetValue(element, out node);
 
     //// TODO: Not sure how long this takes, so maybe wrap in a Task? Though does require UIThread...hmmm
     public void Initialize(XmlDocumentSyntax docRoot, DependencyObject visualRoot)
@@ -351,10 +345,10 @@ public class XamlXmlTreeCoordinator
         // TODO: Think about or time against a DFS instead to see which is more efficient, not sure if case-by-case.
         // Or maybe if we use DFS with a limited depth, as theoretically we shouldn't have to dig far if we're snapping above
         Queue<DependencyObject> queue = new();
-        HashSet<DependencyObject> explored = new()
-        {
+        HashSet<DependencyObject> explored =
+        [
             visualNode
-        };
+        ];
         queue.Enqueue(visualNode);
         while (queue.Count > 0)
         {

--- a/XamlStudio/Activation/ActivationHandler.cs
+++ b/XamlStudio/Activation/ActivationHandler.cs
@@ -19,18 +19,9 @@ internal abstract class ActivationHandler<T> : ActivationHandler
 {
     protected abstract Task HandleInternalAsync(T args);
 
-    public override async Task HandleAsync(object args)
-    {
-        await HandleInternalAsync(args as T);
-    }
+    public override async Task HandleAsync(object args) => await HandleInternalAsync(args as T);
 
-    public override bool CanHandle(object args)
-    {
-        return args is T && CanHandleInternal(args as T);
-    }
+    public override bool CanHandle(object args) => args is T t && CanHandleInternal(t);
 
-    protected virtual bool CanHandleInternal(T args)
-    {
-        return true;
-    }
+    protected virtual bool CanHandleInternal(T args) => true;
 }

--- a/XamlStudio/Activation/DefaultLaunchActivationHandler.cs
+++ b/XamlStudio/Activation/DefaultLaunchActivationHandler.cs
@@ -29,9 +29,7 @@ internal class DefaultLaunchActivationHandler : ActivationHandler<LaunchActivate
         await Task.CompletedTask;
     }
 
-    protected override bool CanHandleInternal(LaunchActivatedEventArgs args)
-    {
+    protected override bool CanHandleInternal(LaunchActivatedEventArgs args) =>
         // None of the ActivationHandlers has handled the app activation
-        return NavigationService.Frame.Content == null;
-    }
+        NavigationService.Frame.Content == null;
 }

--- a/XamlStudio/Activation/FileActivationHandler.cs
+++ b/XamlStudio/Activation/FileActivationHandler.cs
@@ -38,10 +38,8 @@ internal class FileActivationHandler : ActivationHandler<FileActivatedEventArgs>
         await Task.CompletedTask;
     }
 
-    protected override bool CanHandleInternal(FileActivatedEventArgs args)
-    {
+    protected override bool CanHandleInternal(FileActivatedEventArgs args) =>
         // If your app has multiple handlers of FileActivationEventArgs
         // use this method to determine which to use. (possibly checking args.Files)
-        return true;
-    }
+        true;
 }

--- a/XamlStudio/Activation/SchemeActivationHandler.cs
+++ b/XamlStudio/Activation/SchemeActivationHandler.cs
@@ -51,10 +51,8 @@ internal class SchemeActivationHandler : ActivationHandler<ProtocolActivatedEven
         await Task.CompletedTask;
     }
 
-    protected override bool CanHandleInternal(ProtocolActivatedEventArgs args)
-    {
+    protected override bool CanHandleInternal(ProtocolActivatedEventArgs args) =>
         // If your app has multiple handlers of ProtocolActivationEventArgs
         // use this method to determine which to use. (possibly checking args.Uri.Scheme)
-        return true;
-    }
+        true;
 }

--- a/XamlStudio/Activation/WebToAppLinkActivationHandler.cs
+++ b/XamlStudio/Activation/WebToAppLinkActivationHandler.cs
@@ -40,8 +40,5 @@ internal class WebToAppLinkActivationHandler : ActivationHandler<ProtocolActivat
         await Task.CompletedTask;
     }
 
-    protected override bool CanHandleInternal(ProtocolActivatedEventArgs args)
-    {
-        return args?.Uri?.Host == Host;
-    }
+    protected override bool CanHandleInternal(ProtocolActivatedEventArgs args) => args?.Uri?.Host == Host;
 }

--- a/XamlStudio/App.xaml.cs
+++ b/XamlStudio/App.xaml.cs
@@ -25,10 +25,7 @@ namespace XamlStudio;
 public sealed partial class App : Application
 {
     private Lazy<ActivationService> _activationService;
-    private ActivationService ActivationService
-    {
-        get { return _activationService.Value; }
-    }
+    private ActivationService ActivationService => _activationService.Value;
 
     public App()
     {
@@ -77,10 +74,7 @@ public sealed partial class App : Application
         await ActivationService.ActivateAsync(args);
     }
 
-    private ActivationService CreateActivationService()
-    {
-        return new ActivationService(this, typeof(Views.MainPage));
-    }
+    private ActivationService CreateActivationService() => new ActivationService(this, typeof(Views.MainPage));
 
     private async void App_EnteredBackground(object sender, EnteredBackgroundEventArgs e)
     {
@@ -116,9 +110,7 @@ public sealed partial class App : Application
     /// Handles the event of extended execution being revoked.
     /// </summary>
     private void App_ExtendedExecutionRevoked(object sender, ExtendedExecutionRevokedEventArgs args)
-    {
-        AppLoggerService.LogInfo($"The request to ExtendedExecutionSession was revoked with reason {args.Reason}");
-    }
+        => AppLoggerService.LogInfo($"The request to ExtendedExecutionSession was revoked with reason {args.Reason}");
 
     /// <summary>
     /// Invoked when application execution is being resummed.

--- a/XamlStudio/Controls/AppFontIcon.cs
+++ b/XamlStudio/Controls/AppFontIcon.cs
@@ -16,10 +16,7 @@ public class AppFontIcon : FontIcon
     /// call ApplyTemplate. In simplest terms, this means the method is called just before a UI element 
     /// displays in your app. Override this method to influence the default post-template logic of a class.
     /// </summary>
-    protected override void OnApplyTemplate()
-    {
-        base.OnApplyTemplate();
-    }
+    protected override void OnApplyTemplate() => base.OnApplyTemplate();
 
     #region IconName (Dependency Property)
 
@@ -148,15 +145,12 @@ public static class IconGlyphValues
     /// <summary>
     /// Tries to get a unicode value out of the given icon name.
     /// </summary>
-    public static string GetIcon(IconGlyphNames icon)
-    {
-        return IconMapping.TryGetValue(icon, out string value) ? value : string.Empty;
-    }
+    public static string GetIcon(IconGlyphNames icon) => IconMapping.TryGetValue(icon, out string value) ? value : string.Empty;
 
     /// <summary>
     /// Maps the icon names into unicode values.
     /// </summary>
-    private static readonly Dictionary<IconGlyphNames, string> IconMapping = new Dictionary<IconGlyphNames, string>()
+    private static readonly Dictionary<IconGlyphNames, string> IconMapping = new()
     {
         {IconGlyphNames.Search,     "\uE721"},
         {IconGlyphNames.Work,       "\uE821"},
@@ -199,16 +193,14 @@ public static class IconSizeValues
     /// <summary>
     /// Tries to get a numercal value out of the indicated name.
     /// </summary>
-    public static double GetIconSize(IconContexts sizeName)
-    {
+    public static double GetIconSize(IconContexts sizeName) =>
         // Default Value is 16 based on ContentControlFontSize from ThemeResources
-        return SizeMapping.TryGetValue(sizeName, out double value) ? value : 16.0;
-    }
+        SizeMapping.TryGetValue(sizeName, out double value) ? value : 16.0;
 
     /// <summary>
     /// Maps the Size names to numerical values.
     /// </summary>
-    private static readonly Dictionary<IconContexts, double> SizeMapping = new Dictionary<IconContexts, double>()
+    private static readonly Dictionary<IconContexts, double> SizeMapping = new()
     {
         {IconContexts.Smaller,       10.0 },
         {IconContexts.Small,         12.0 },

--- a/XamlStudio/Helpers/EnumValueExtension.cs
+++ b/XamlStudio/Helpers/EnumValueExtension.cs
@@ -15,8 +15,5 @@ public class EnumValueExtension : MarkupExtension
 
     public string Member { get; set; }
 
-    protected override object ProvideValue()
-    {
-        return Enum.Parse(Type, Member);
-    }
+    protected override object ProvideValue() => Enum.Parse(Type, Member);
 }

--- a/XamlStudio/Helpers/Json.cs
+++ b/XamlStudio/Helpers/Json.cs
@@ -11,28 +11,22 @@ namespace XamlStudio.Helpers;
 public static class Json
 {
     public static async Task<T> ToObjectAsync<T>(string value)
-    {
-        return await Task.Run<T>(() =>
-        {
-            return JsonConvert.DeserializeObject<T>(value);
-        });
-    }
+        => await Task.Run<T>(() =>
+            {
+                return JsonConvert.DeserializeObject<T>(value);
+            });
 
     public static async Task<object> ToObjectAsync(string value, Type type)
-    {
-        return await Task.Run(() =>
-        {
-            return JsonConvert.DeserializeObject(value, type);
-        });
-    }
+        => await Task.Run(() =>
+            {
+                return JsonConvert.DeserializeObject(value, type);
+            });
 
     public static async Task<string> StringifyAsync(object value)
-    {
-        return await Task.Run<string>(() =>
-        {
-            return JsonConvert.SerializeObject(value);
-        });
-    }
+        => await Task.Run<string>(() =>
+            {
+                return JsonConvert.SerializeObject(value);
+            });
 
     public static object GetDefault(this Type type)
     {

--- a/XamlStudio/Helpers/NavIconHelper.cs
+++ b/XamlStudio/Helpers/NavIconHelper.cs
@@ -10,15 +10,9 @@ namespace XamlStudio.Helpers;
 
 internal class NavItemIconHelper
 {
-    public static object GetSelectedIcon(NavigationViewItem obj)
-    {
-        return obj.GetValue(SelectedIconProperty);
-    }
+    public static object GetSelectedIcon(NavigationViewItem obj) => obj.GetValue(SelectedIconProperty);
 
-    public static void SetSelectedIcon(NavigationViewItem obj, object value)
-    {
-        obj.SetValue(SelectedIconProperty, value);
-    }
+    public static void SetSelectedIcon(NavigationViewItem obj, object value) => obj.SetValue(SelectedIconProperty, value);
 
     public static readonly DependencyProperty SelectedIconProperty =
         DependencyProperty.RegisterAttached("SelectedIcon", typeof(object), typeof(NavItemIconHelper), new PropertyMetadata(null));
@@ -27,18 +21,12 @@ internal class NavItemIconHelper
     /// Gets the value of <see cref="ShowNotificationDotProperty" /> for a <see cref="DependencyObject" />
     /// </summary>
     /// <returns>Returns a boolean indicating whether the notification dot should be shown.</returns>
-    public static bool GetShowNotificationDot(NavigationViewItem obj)
-    {
-        return (bool)obj.GetValue(ShowNotificationDotProperty);
-    }
+    public static bool GetShowNotificationDot(NavigationViewItem obj) => (bool)obj.GetValue(ShowNotificationDotProperty);
 
     /// <summary>
     /// Sets <see cref="ShowNotificationDotProperty" /> on a <see cref="DependencyObject" />
     /// </summary>
-    public static void SetShowNotificationDot(NavigationViewItem obj, bool value)
-    {
-        obj.SetValue(ShowNotificationDotProperty, value);
-    }
+    public static void SetShowNotificationDot(NavigationViewItem obj, bool value) => obj.SetValue(ShowNotificationDotProperty, value);
 
     /// <summary>
     /// An attached property that sets whether or not a notification dot should be shown on an associated <see cref="NavigationViewItem" />
@@ -50,18 +38,12 @@ internal class NavItemIconHelper
     /// Gets the value of <see cref="UnselectedIconProperty"/> for a <see cref="DependencyObject"/>
     /// </summary>
     /// <returns>Returns the unselected icon as an object.</returns>
-    public static object GetUnselectedIcon(NavigationViewItem obj)
-    {
-        return (object)obj.GetValue(UnselectedIconProperty);
-    }
+    public static object GetUnselectedIcon(NavigationViewItem obj) => (object)obj.GetValue(UnselectedIconProperty);
 
     /// <summary>
     /// Sets the value of <see cref="UnselectedIconProperty"/> for a <see cref="DependencyObject"/>
     /// </summary>
-    public static void SetUnselectedIcon(NavigationViewItem obj, object value)
-    {
-        obj.SetValue(UnselectedIconProperty, value);
-    }
+    public static void SetUnselectedIcon(NavigationViewItem obj, object value) => obj.SetValue(UnselectedIconProperty, value);
 
     /// <summary>
     /// An attached property that sets the unselected icon on an associated <see cref="NavigationViewItem" />
@@ -69,15 +51,9 @@ internal class NavItemIconHelper
     public static readonly DependencyProperty UnselectedIconProperty =
         DependencyProperty.RegisterAttached("UnselectedIcon", typeof(object), typeof(NavItemIconHelper), new PropertyMetadata(null));
 
-    public static Visibility GetStaticIconVisibility(NavigationViewItem obj)
-    {
-        return (Visibility)obj.GetValue(StaticIconVisibilityProperty);
-    }
+    public static Visibility GetStaticIconVisibility(NavigationViewItem obj) => (Visibility)obj.GetValue(StaticIconVisibilityProperty);
 
-    public static void SetStaticIconVisibility(NavigationViewItem obj, Visibility value)
-    {
-        obj.SetValue(StaticIconVisibilityProperty, value);
-    }
+    public static void SetStaticIconVisibility(NavigationViewItem obj, Visibility value) => obj.SetValue(StaticIconVisibilityProperty, value);
 
     /// <summary>
     /// An attached property that sets the visibility of the static icon in the associated <see cref="NavigationViewItem"/>.

--- a/XamlStudio/Helpers/ResourceExtensions.cs
+++ b/XamlStudio/Helpers/ResourceExtensions.cs
@@ -8,10 +8,7 @@ namespace XamlStudio.Helpers;
 
 internal static class ResourceExtensions
 {
-    private static ResourceLoader _resLoader = new ResourceLoader();
+    private static ResourceLoader _resLoader = new();
 
-    public static string GetLocalized(this string resourceKey)
-    {
-        return _resLoader.GetString(resourceKey);
-    }
+    public static string GetLocalized(this string resourceKey) => _resLoader.GetString(resourceKey);
 }

--- a/XamlStudio/Helpers/SettingsStorageExtensions.cs
+++ b/XamlStudio/Helpers/SettingsStorageExtensions.cs
@@ -17,14 +17,11 @@ namespace XamlStudio.Helpers;
 // https://docs.microsoft.com/windows/uwp/app-settings/store-and-retrieve-app-data
 public static class SettingsStorageExtensions
 {
-    private static readonly AsyncLock _saveMutex = new AsyncLock();
+    private static readonly AsyncLock _saveMutex = new();
 
     private const string FileExtension = ".json";
 
-    public static bool IsRoamingStorageAvailable(this ApplicationData appData)
-    {
-        return appData.RoamingStorageQuota == 0;
-    }
+    public static bool IsRoamingStorageAvailable(this ApplicationData appData) => appData.RoamingStorageQuota == 0;
 
     public static async Task SaveAsync<T>(this StorageFolder folder, string name, T content)
     {
@@ -59,7 +56,7 @@ public static class SettingsStorageExtensions
         {
             if (!File.Exists(Path.Combine(folder.Path, GetFileName(name))))
             {
-                return default(T);
+                return default;
             }
 
             var file = await folder.GetFileAsync($"{name}.json");
@@ -69,15 +66,9 @@ public static class SettingsStorageExtensions
         }
     }
 
-    public static async Task SaveAsync<T>(this ApplicationDataContainer settings, string key, T value)
-    {
-        settings.SaveString(key, await Json.StringifyAsync(value));
-    }
+    public static async Task SaveAsync<T>(this ApplicationDataContainer settings, string key, T value) => settings.SaveString(key, await Json.StringifyAsync(value));
 
-    public static void SaveString(this ApplicationDataContainer settings, string key, string value)
-    {
-        settings.Values[key] = value;
-    }
+    public static void SaveString(this ApplicationDataContainer settings, string key, string value) => settings.Values[key] = value;
 
     public static async Task<T> ReadAsync<T>(this ApplicationDataContainer settings, string key)
     {
@@ -86,7 +77,7 @@ public static class SettingsStorageExtensions
             return await Json.ToObjectAsync<T>((string)obj);
         }
 
-        return default(T);
+        return default;
     }
 
     public static async Task<object> ReadAsync(this ApplicationDataContainer settings, string key, Type type)
@@ -139,24 +130,17 @@ public static class SettingsStorageExtensions
         {
             using (await _saveMutex.LockAsync())
             {
-                using (IRandomAccessStream stream = await file.OpenReadAsync())
-                {
-                    using (var reader = new DataReader(stream.GetInputStreamAt(0)))
-                    {
-                        await reader.LoadAsync((uint)stream.Size);
-                        var bytes = new byte[stream.Size];
-                        reader.ReadBytes(bytes);
-                        return bytes;
-                    }
-                }
+                using IRandomAccessStream stream = await file.OpenReadAsync();
+                using var reader = new DataReader(stream.GetInputStreamAt(0));
+                await reader.LoadAsync((uint)stream.Size);
+                var bytes = new byte[stream.Size];
+                reader.ReadBytes(bytes);
+                return bytes;
             }
         }
 
         return null;
     }
 
-    private static string GetFileName(string name)
-    {
-        return string.Concat(name, FileExtension);
-    }
+    private static string GetFileName(string name) => string.Concat(name, FileExtension);
 }

--- a/XamlStudio/Models/DataContext.cs
+++ b/XamlStudio/Models/DataContext.cs
@@ -18,7 +18,7 @@ public sealed partial class DataContext : FileBackedDocument
     [NotifyPropertyChangedFor(nameof(IsRemote))]
     public partial string Uri { get; set; }
 
-    public bool IsRemote { get { return !string.IsNullOrWhiteSpace(Uri); } }
+    public bool IsRemote => !string.IsNullOrWhiteSpace(Uri);
 
     internal DataContext() : base() { }
 

--- a/XamlStudio/Models/FileBackedDocument.cs
+++ b/XamlStudio/Models/FileBackedDocument.cs
@@ -44,7 +44,7 @@ public abstract partial class FileBackedDocument : ObservableObject
     [NotifyPropertyChangedFor(nameof(Title))]
     public partial bool HasChanged { get; set; }
 
-    public bool CanSave { get { return BackingFile != null; } }
+    public bool CanSave => BackingFile != null;
 
     public FileBackedDocument() { }
 
@@ -86,10 +86,7 @@ public abstract partial class FileBackedDocument : ObservableObject
     /// Save a file back to its backing location.
     /// </summary>
     /// <returns></returns>
-    public IAsyncOperation<bool> SaveAsync()
-    {
-        return SaveAsyncInternal().AsAsyncOperation();
-    }
+    public IAsyncOperation<bool> SaveAsync() => SaveAsyncInternal().AsAsyncOperation();
 
     private async Task<bool> SaveAsyncInternal()
     {
@@ -119,10 +116,7 @@ public abstract partial class FileBackedDocument : ObservableObject
     /// </summary>
     /// <param name="newFile">New File Storage Location.</param>
     /// <returns></returns>
-    public IAsyncOperation<bool> SaveAsAsync(StorageFile newFile)
-    {
-        return SaveAsAsyncInternal(newFile).AsAsyncOperation();
-    }
+    public IAsyncOperation<bool> SaveAsAsync(StorageFile newFile) => SaveAsAsyncInternal(newFile).AsAsyncOperation();
 
     private async Task<bool> SaveAsAsyncInternal(StorageFile newFile)
     {

--- a/XamlStudio/Models/FolderLocation.cs
+++ b/XamlStudio/Models/FolderLocation.cs
@@ -28,7 +28,7 @@ public partial class FolderLocation : ObservableObject
     [NotifyPropertyChangedFor(nameof(IsInitialized))]
     public partial StorageFolder BackingFolder { get; set; }
 
-    public bool IsInitialized { get { return BackingFolder != null; } }
+    public bool IsInitialized => BackingFolder != null;
 
     public FolderLocation() { }
 

--- a/XamlStudio/Models/ThirdPartyInfo.cs
+++ b/XamlStudio/Models/ThirdPartyInfo.cs
@@ -23,7 +23,7 @@ public class ThirdPartyInfo
     public string License { get; set; }
 
     [JsonIgnore]
-    public string LicenseAutomationName { get { return string.Format("License_Name_Format".GetLocalized(), License, Name); } }
+    public string LicenseAutomationName => string.Format("License_Name_Format".GetLocalized(), License, Name);
 
     [JsonProperty("license_url")]
     public string LicenseUrl { get; set; }
@@ -32,6 +32,6 @@ public class ThirdPartyInfo
     public List<string> LicenseText { get; set; }
 
     [JsonIgnore]
-    public string LicenseTextAutomationName { get { return string.Format("License_Text_Format".GetLocalized(), License, Name); } }
+    public string LicenseTextAutomationName => string.Format("License_Text_Format".GetLocalized(), License, Name);
 
 }

--- a/XamlStudio/Models/WorkspaceWindow.cs
+++ b/XamlStudio/Models/WorkspaceWindow.cs
@@ -27,9 +27,9 @@ public abstract partial class WorkspaceWindow : ObservableObject
     [ObservableProperty]
     public partial bool IsWorkspaceOpen { get; set; }
 
-    public ObservableCollection<FolderLocation> WorkspaceFolders { get; private set; } = new();
+    public ObservableCollection<FolderLocation> WorkspaceFolders { get; private set; } = [];
 
-    public ObservableCollection<XamlDocument> OpenFiles { get; private set; } = new();
+    public ObservableCollection<XamlDocument> OpenFiles { get; private set; } = [];
 
     public WorkspaceWindow()
     {
@@ -38,13 +38,11 @@ public abstract partial class WorkspaceWindow : ObservableObject
 
     public abstract void Initialize();
 
-    public static WorkspaceWindow GetDefaultWorkspace()
-    {
+    public static WorkspaceWindow GetDefaultWorkspace() =>
         //SettingsService.Instance.DefaultWorkspaceFolder
         // Get Settings Folder
         // IsWorkspaceOpen = false still.
         throw new NotImplementedException();
-    }
 
     public void SetupWorkspace(StorageFolder folder)
     {
@@ -76,8 +74,5 @@ public abstract partial class WorkspaceWindow : ObservableObject
         ActiveFileChanged?.Invoke(this, newValue);
     }
 
-    partial void OnOpenActivityChanged(string value)
-    {
-        WeakReferenceMessenger.Default.Send<OpenActivityChangedMessage>(new(value));
-    }
+    partial void OnOpenActivityChanged(string value) => WeakReferenceMessenger.Default.Send<OpenActivityChangedMessage>(new(value));
 }

--- a/XamlStudio/Models/XamlDocument.cs
+++ b/XamlStudio/Models/XamlDocument.cs
@@ -38,7 +38,7 @@ public sealed partial class XamlDocument : FileBackedDocument
     public partial DocumentState State { get; set; } = new DocumentState();
 
     [JsonIgnore]
-    public string DisplayName { get { return BackingFile.DisplayName; } }
+    public string DisplayName => BackingFile.DisplayName;
 
     internal XamlDocument()
     {
@@ -55,15 +55,9 @@ public sealed partial class XamlDocument : FileBackedDocument
         Initialize();
     }
 
-    private void Initialize()
-    {
-        Id = _id; // for first set unless deserialized
-    }
+    private void Initialize() => Id = _id; // for first set unless deserialized
 
-    public override string ToString()
-    {
-        return Title;
-    }
+    public override string ToString() => Title;
 
     /// <summary>
     /// Create a XamlDocument from an existing location.

--- a/XamlStudio/Services/ActivationService.cs
+++ b/XamlStudio/Services/ActivationService.cs
@@ -102,16 +102,11 @@ internal class ActivationService
         yield return Singleton<FileActivationHandler>.Instance;
     }
 
-    private bool IsInteractive(object args)
-    {
-        return args is IActivatedEventArgs;
-    }
+    private bool IsInteractive(object args) => args is IActivatedEventArgs;
 
     private void Frame_Navigated(object sender, NavigationEventArgs e)
-    {
-        SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = NavigationService.CanGoBack ?
+        => SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = NavigationService.CanGoBack ?
             AppViewBackButtonVisibility.Visible : AppViewBackButtonVisibility.Collapsed;
-    }
 
     private void ActivationService_BackRequested(object sender, BackRequestedEventArgs e)
     {

--- a/XamlStudio/Services/AppLoggerService.cs
+++ b/XamlStudio/Services/AppLoggerService.cs
@@ -17,7 +17,7 @@ namespace XamlStudio.Services;
 /// </summary>
 public static class AppLoggerService
 {
-    private static readonly object locker = new object();
+    private static readonly object locker = new();
     private static FileLogger fileLogger;
     private static Guid sessionGuid;
 
@@ -38,10 +38,7 @@ public static class AppLoggerService
     /// <summary>
     /// Application session identifier gets assigned every time the application gets activated.
     /// </summary>
-    public static Guid SessionId
-    {
-        get { return sessionGuid; }
-    }
+    public static Guid SessionId => sessionGuid;
 
     /// <summary>
     /// Resets the session guid used by the app.
@@ -64,37 +61,25 @@ public static class AppLoggerService
     /// <summary>
     /// Causes the file logger to store all the messages it hasn't saved to disk.
     /// </summary>
-    public static void FlushMessages()
-    {
-        Task.Run(() => fileLogger.FlushMessagesAsync(LogFileType.All)).Wait();
-    }
+    public static void FlushMessages() => Task.Run(() => fileLogger.FlushMessagesAsync(LogFileType.All)).Wait();
 
     /// <summary>
     /// Notifies the <see cref="FileLogger"/> that the app is entering into suspension mode.
     /// </summary>
     /// <returns></returns>
-    public static Task OnSuspending()
-    {
-        return fileLogger.OnSuspending();
-    }
+    public static Task OnSuspending() => fileLogger.OnSuspending();
 
     /// <summary>
     /// NOtifies the <see cref="FileLogger"/> that the app is entering into resume mode.
     /// </summary>
-    public static void OnResuming()
-    {
-        fileLogger.OnResuming();
-    }
+    public static void OnResuming() => fileLogger.OnResuming();
 
     #region LogInfo
     /// <summary>
     /// Logs an informational message.
     /// </summary>
     /// <param name="message"></param>
-    public static void LogInfo(string message)
-    {
-        fileLogger.Log(message, LoggingLevel.Information);
-    }
+    public static void LogInfo(string message) => fileLogger.Log(message, LoggingLevel.Information);
 
     /// <summary>
     /// Logs an informational message with format.
@@ -117,33 +102,22 @@ public static class AppLoggerService
     /// Logs an error message with any acompanying exception.
     /// </summary>
     private static void LogError(string caller, string message = null, Exception ex = null, LoggingLevel logLevel = LoggingLevel.Error)
-    {
-        fileLogger.Log($"AppError[{caller}]: {message ?? string.Empty} | Exception: {ex?.ToString()}", logLevel);
-    }
+        => fileLogger.Log($"AppError[{caller}]: {message ?? string.Empty} | Exception: {ex?.ToString()}", logLevel);
 
     /// <summary>
     /// Logs an exception only.
     /// </summary>
-    public static void LogError(Exception e, [CallerMemberName] string caller = "")
-    {
-        LogError(caller: caller, message: null, ex: e);
-    }
+    public static void LogError(Exception e, [CallerMemberName] string caller = "") => LogError(caller: caller, message: null, ex: e);
 
     /// <summary>
     /// Logs an error message.
     /// </summary>
-    public static void LogError(string message, [CallerMemberName] string caller = "")
-    {
-        LogError(caller: caller, message: message, ex: null);
-    }
+    public static void LogError(string message, [CallerMemberName] string caller = "") => LogError(caller: caller, message: message, ex: null);
 
     /// <summary>
     ///  Logs an error message with exception details.
     /// </summary>
-    public static void LogError(string message, Exception e, [CallerMemberName] string caller = "")
-    {
-        LogError(caller: caller, message: message, ex: e);
-    }
+    public static void LogError(string message, Exception e, [CallerMemberName] string caller = "") => LogError(caller: caller, message: message, ex: e);
 
     #endregion
 

--- a/XamlStudio/Services/LibraryService.cs
+++ b/XamlStudio/Services/LibraryService.cs
@@ -22,11 +22,11 @@ public class LibraryService
 {
     public static LibraryService Instance => Singleton<LibraryService>.Instance;
 
-    public ObservableCollection<LibraryInfo> Libraries { get; private set; } = new ObservableCollection<LibraryInfo>();
+    public ObservableCollection<LibraryInfo> Libraries { get; private set; } = [];
 
     public Dictionary<string, LibraryInfo> LibrariesByNamespace { get; private set; }
 
-    private readonly AsyncLock _initializeMutex = new AsyncLock();
+    private readonly AsyncLock _initializeMutex = new();
     private bool _isInitialized = false;
 
     public LibraryService()

--- a/XamlStudio/Services/Logging/FileLogger.cs
+++ b/XamlStudio/Services/Logging/FileLogger.cs
@@ -23,10 +23,10 @@ internal class FileLogger
     private const string AppLogSchemaName = "XamlStudioLog";
 
     private static bool isInitialized = false;
-    private static object lockObject = new object();
-    private static SemaphoreSlim flushSemaphore = new SemaphoreSlim(1);
+    private static object lockObject = new();
+    private static SemaphoreSlim flushSemaphore = new(1);
 
-    private static readonly Lazy<FileLogger> instance = new Lazy<FileLogger>(
+    private static readonly Lazy<FileLogger> instance = new(
         () => new FileLogger(), LazyThreadSafetyMode.ExecutionAndPublication);
 
     private ConcurrentQueue<string> plainTextMessages;
@@ -47,10 +47,7 @@ internal class FileLogger
     /// <summary>
     /// Returns the Singleton instance of <see cref="FileLogger"/>.
     /// </summary>
-    public static FileLogger Instance
-    {
-        get { return instance.Value; }
-    }
+    public static FileLogger Instance => instance.Value;
 
     private FileLogger()
     {
@@ -96,18 +93,12 @@ internal class FileLogger
     /// <summary>
     /// Handles the event of the application entering into suspension.
     /// </summary>
-    public Task OnSuspending()
-    {
-        return FlushMessagesAsync(LogFileType.All);
-    }
+    public Task OnSuspending() => FlushMessagesAsync(LogFileType.All);
 
     /// <summary>
     /// Triggers actions when the application resumes.
     /// </summary>
-    public void OnResuming()
-    {
-        InitSession();
-    }
+    public void OnResuming() => InitSession();
 
     /// <summary>
     /// Flushes all the messages currently in processing to storage area.
@@ -143,10 +134,7 @@ internal class FileLogger
     /// <summary>
     /// Handles the event when a log file is saved by <see cref="FileLoggingSession"/>
     /// </summary>
-    private async void OnLogFileGenerated(IFileLoggingSession sender, LogFileGeneratedEventArgs args)
-    {
-        await MoveLogFileToLogFolder(args.File);
-    }
+    private async void OnLogFileGenerated(IFileLoggingSession sender, LogFileGeneratedEventArgs args) => await MoveLogFileToLogFolder(args.File);
 
     /// <summary>
     /// Closes the active log session and grabs the current log file to get it stored.
@@ -176,8 +164,7 @@ internal class FileLogger
             var messagesToFlush = new Queue<string>();
             while (true)
             {
-                string logMessage;
-                if (plainTextMessages.TryDequeue(out logMessage))
+                if (plainTextMessages.TryDequeue(out string logMessage))
                 {
                     messagesToFlush.Enqueue(logMessage);
                 }
@@ -218,10 +205,7 @@ internal class FileLogger
         if (logFile != null)
         {
             StorageFolder targetFolder = logFolder;
-            if (targetFolder == null)
-            {
-                targetFolder = await GetAppLogFolderAsync();
-            }
+            targetFolder ??= await GetAppLogFolderAsync();
 
             string logFileName = GenerateLogFileName(LogFileType.EventTraceLog, DateTime.Now);
             await logFile.MoveAsync(targetFolder, logFileName, NameCollisionOption.GenerateUniqueName);
@@ -269,10 +253,7 @@ internal class FileLogger
     /// </summary>
     public async Task<StorageFolder> GetAppLogFolderAsync()
     {
-        if (logFolder == null)
-        {
-            logFolder = await ApplicationData.Current.TemporaryFolder.CreateFolderAsync(logFolderName, CreationCollisionOption.OpenIfExists);
-        }
+        logFolder ??= await ApplicationData.Current.TemporaryFolder.CreateFolderAsync(logFolderName, CreationCollisionOption.OpenIfExists);
 
         return logFolder;
     }
@@ -282,8 +263,7 @@ internal class FileLogger
     /// </summary>
     private string GetDateTimePath(DateTime date)
     {
-        string timeString = string.Empty;
-
+        string timeString;
         try
         {
             timeString = date.ToString(new DateTimeFormatInfo().SortableDateTimePattern, CultureInfo.InvariantCulture);
@@ -313,17 +293,12 @@ internal class FileLogger
     /// <summary>
     /// Gets the file type extension to use based on the <see cref="LogFileType"/>.
     /// </summary>
-    private string GetFileExtension(LogFileType fileType)
+    private string GetFileExtension(LogFileType fileType) => fileType switch
     {
-        switch (fileType)
-        {
-            case LogFileType.EventTraceLog:
-                return "etl";
-            case LogFileType.Text:
-                return "txt";
-        }
-        return "etl";
-    }
+        LogFileType.EventTraceLog => "etl",
+        LogFileType.Text => "txt",
+        _ => "etl",
+    };
 }
 
 /// <summary>

--- a/XamlStudio/Services/SettingsService.cs
+++ b/XamlStudio/Services/SettingsService.cs
@@ -21,7 +21,7 @@ public partial class SettingsService : ObservableObject
 {
     public static SettingsService Instance => Singleton<SettingsService>.Instance;
 
-    private readonly AsyncLock _initializeMutex = new AsyncLock();
+    private readonly AsyncLock _initializeMutex = new();
     private bool _isInitialized = false;
 
     public SettingsService()
@@ -85,13 +85,13 @@ public partial class SettingsService : ObservableObject
     }
 
     // Internal Cache
-    private static Dictionary<string, object> _settings = new Dictionary<string, object>();
+    private static Dictionary<string, object> _settings = [];
 
     public T Get<T>([CallerMemberName] string propertyName = null)
     {
         if (propertyName == null || !_settings.ContainsKey(propertyName))
         {
-            return default(T);
+            return default;
         }
 
         return (T)_settings[propertyName];

--- a/XamlStudio/Services/SuspendAndResumeService.cs
+++ b/XamlStudio/Services/SuspendAndResumeService.cs
@@ -17,7 +17,7 @@ namespace XamlStudio.Services;
 
 internal class SuspendAndResumeService : ActivationHandler<LaunchActivatedEventArgs>
 {
-    private readonly AsyncLock _suspendMutex = new AsyncLock();
+    private readonly AsyncLock _suspendMutex = new();
 
     //// TODO WTS: For more information regarding the application lifecycle and how to handle suspend and resume, please see:
     //// Documentation: https://docs.microsoft.com/windows/uwp/launch-resume/app-lifecycle
@@ -47,15 +47,9 @@ internal class SuspendAndResumeService : ActivationHandler<LaunchActivatedEventA
         }
     }
 
-    protected override async Task HandleInternalAsync(LaunchActivatedEventArgs args)
-    {
-        await RestoreStateAsync();
-    }
+    protected override async Task HandleInternalAsync(LaunchActivatedEventArgs args) => await RestoreStateAsync();
 
-    protected override bool CanHandleInternal(LaunchActivatedEventArgs args)
-    {
-        return true;
-    }
+    protected override bool CanHandleInternal(LaunchActivatedEventArgs args) => true;
 
     private async Task RestoreStateAsync()
     {

--- a/XamlStudio/Services/ThemeSelectorService.cs
+++ b/XamlStudio/Services/ThemeSelectorService.cs
@@ -18,10 +18,7 @@ public static class ThemeSelectorService
 
     public static ElementTheme Theme { get; set; } = ElementTheme.Default;
 
-    public static async Task InitializeAsync()
-    {
-        Theme = await LoadThemeFromSettingsAsync();
-    }
+    public static async Task InitializeAsync() => Theme = await LoadThemeFromSettingsAsync();
 
     public static async Task SetThemeAsync(ElementTheme theme)
     {
@@ -52,8 +49,5 @@ public static class ThemeSelectorService
         return cacheTheme;
     }
 
-    private static async Task SaveThemeInSettingsAsync(ElementTheme theme)
-    {
-        await ApplicationData.Current.LocalSettings.SaveAsync(SettingsKey, theme.ToString());
-    }
+    private static async Task SaveThemeInSettingsAsync(ElementTheme theme) => await ApplicationData.Current.LocalSettings.SaveAsync(SettingsKey, theme.ToString());
 }

--- a/XamlStudio/Services/ViewLifetimeControl.cs
+++ b/XamlStudio/Services/ViewLifetimeControl.cs
@@ -72,10 +72,7 @@ public sealed class ViewLifetimeControl
         RegisterForEvents();
     }
 
-    public static ViewLifetimeControl CreateForCurrentView()
-    {
-        return new ViewLifetimeControl(CoreWindow.GetForCurrentThread());
-    }
+    public static ViewLifetimeControl CreateForCurrentView() => new ViewLifetimeControl(CoreWindow.GetForCurrentThread());
 
     // Signals that the view is being interacted with by another view,
     // so it shouldn't be closed even if it becomes "consolidated"
@@ -129,20 +126,11 @@ public sealed class ViewLifetimeControl
         return refCountCopy;
     }
 
-    private void RegisterForEvents()
-    {
-        ApplicationView.GetForCurrentView().Consolidated += ViewConsolidated;
-    }
+    private void RegisterForEvents() => ApplicationView.GetForCurrentView().Consolidated += ViewConsolidated;
 
-    private void UnregisterForEvents()
-    {
-        ApplicationView.GetForCurrentView().Consolidated -= ViewConsolidated;
-    }
+    private void UnregisterForEvents() => ApplicationView.GetForCurrentView().Consolidated -= ViewConsolidated;
 
-    private void ViewConsolidated(ApplicationView sender, ApplicationViewConsolidatedEventArgs e)
-    {
-        StopViewInUse();
-    }
+    private void ViewConsolidated(ApplicationView sender, ApplicationViewConsolidatedEventArgs e) => StopViewInUse();
 
     private void FinalizeRelease()
     {

--- a/XamlStudio/Services/WindowManagerService.cs
+++ b/XamlStudio/Services/WindowManagerService.cs
@@ -23,10 +23,10 @@ public class WindowManagerService
     // https://docs.microsoft.com/windows/uwp/design/layout/show-multiple-views
     private static WindowManagerService _current;
 
-    public static WindowManagerService Current => _current ?? (_current = new WindowManagerService());
+    public static WindowManagerService Current => _current ??= new WindowManagerService();
 
     // Contains all the opened secondary views.
-    public ObservableCollection<ViewLifetimeControl> SecondaryViews { get; } = new ObservableCollection<ViewLifetimeControl>();
+    public ObservableCollection<ViewLifetimeControl> SecondaryViews { get; } = [];
 
     public int MainViewId { get; private set; }
 

--- a/XamlStudio/ViewModels/DocumentViewModel.Methods.cs
+++ b/XamlStudio/ViewModels/DocumentViewModel.Methods.cs
@@ -29,7 +29,7 @@ namespace XamlStudio.ViewModels;
 
 public partial class DocumentViewModel
 {
-    private readonly AsyncLock _renderMutex = new AsyncLock();
+    private readonly AsyncLock _renderMutex = new();
 
     // TODO: Need to offset line with location in document?
     /*private async void SelectiveRenderXaml(string content)
@@ -329,10 +329,7 @@ public partial class DocumentViewModel
         var orientation = Document.State.PreviewOrientation;
 
         // If we're set to default, go grab that value to start from
-        if (orientation == null)
-        {
-            orientation = Settings.DefaultPreviewPanePosition;
-        }
+        orientation ??= Settings.DefaultPreviewPanePosition;
 
         // Go to next enum value
         orientation = (PaneOrientation)((((int)orientation.Value) + 1) % 4);

--- a/XamlStudio/ViewModels/DocumentViewModel.cs
+++ b/XamlStudio/ViewModels/DocumentViewModel.cs
@@ -27,9 +27,7 @@ public partial class DocumentViewModel : ObservableObject
     public partial XamlDocument Document { get; set; }
 
     partial void OnDocumentChanged(XamlDocument value)
-    {
-        HasCompiled = false; // TODO: Reset compiled flag so we can re-render, probably want to cache elements previously rendered in XamlDocument, so we can re-add on document switch
-    }
+        => HasCompiled = false; // TODO: Reset compiled flag so we can re-render, probably want to cache elements previously rendered in XamlDocument, so we can re-add on document switch
 
     /// <summary>
     /// Selected Text in the Editor
@@ -49,7 +47,7 @@ public partial class DocumentViewModel : ObservableObject
     [ObservableProperty]
     public partial XamlXmlTreeCoordinator XamlCoordinator { get; set; } = new();
 
-    private ObservableCollection<ConversionRecord> _bindingHistory = new ObservableCollection<ConversionRecord>();
+    private ObservableCollection<ConversionRecord> _bindingHistory = [];
     public AdvancedCollectionView BindingHistory
     {
         get
@@ -68,33 +66,33 @@ public partial class DocumentViewModel : ObservableObject
 
     public ElementTheme ActualTheme { get; set; }
 
-    public ObservableVector<IModelDeltaDecoration> LineDecorations { get; private set; } = new ObservableVector<IModelDeltaDecoration>();
+    public ObservableVector<IModelDeltaDecoration> LineDecorations { get; private set; } = [];
 
-    private static CssLineStyle _errorLineStyle = new CssLineStyle()
+    private static CssLineStyle _errorLineStyle = new()
     {
         BackgroundColor = new SolidColorBrush("#FFCA416A".ToColor())
     };
 
-    private static CssInlineStyle _errorStyle = new CssInlineStyle()
+    private static CssInlineStyle _errorStyle = new()
     {
         BackgroundColor = new SolidColorBrush("#FFCA416A".ToColor()),
         ForegroundColor = new SolidColorBrush("#FFFFFFFF".ToColor()),
         FontWeight = FontWeights.SemiBold
     };
 
-    private static CssInlineStyle _bindingStyleUnbound = new CssInlineStyle()
+    private static CssInlineStyle _bindingStyleUnbound = new()
     {
         BackgroundColor = new SolidColorBrush("#FFB4EBEF".ToColor()),
         ForegroundColor = new SolidColorBrush("#FF333333".ToColor())
     };
 
-    private static CssInlineStyle _bindingStyleSuccess = new CssInlineStyle()
+    private static CssInlineStyle _bindingStyleSuccess = new()
     {
         BackgroundColor = new SolidColorBrush("#FFB9FEC1".ToColor()),
         ForegroundColor = new SolidColorBrush("#FF333333".ToColor())
     };
 
-    private static CssInlineStyle _bindingStyleError = new CssInlineStyle()
+    private static CssInlineStyle _bindingStyleError = new()
     {
         BackgroundColor = new SolidColorBrush("#FFFFF689".ToColor()),
         ForegroundColor = new SolidColorBrush("#FF663333".ToColor()),

--- a/XamlStudio/ViewModels/MainViewModel.Commands.Impl.cs
+++ b/XamlStudio/ViewModels/MainViewModel.Commands.Impl.cs
@@ -21,7 +21,7 @@ namespace XamlStudio.ViewModels;
 
 public partial class MainViewModel
 {
-    private readonly AsyncLock _openMutex = new AsyncLock();
+    private readonly AsyncLock _openMutex = new();
 
     private void CloseWelcomeScreen()
     {
@@ -64,9 +64,11 @@ public partial class MainViewModel
     [RelayCommand]
     private async Task OpenDocument()
     {
-        var picker = new FileOpenPicker();
-        picker.ViewMode = PickerViewMode.List;
-        picker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
+        var picker = new FileOpenPicker
+        {
+            ViewMode = PickerViewMode.List,
+            SuggestedStartLocation = PickerLocationId.DocumentsLibrary
+        };
         picker.FileTypeFilter.Add(".xaml");
         picker.FileTypeFilter.Add(".xml");
         picker.FileTypeFilter.Add(".bind");
@@ -81,9 +83,7 @@ public partial class MainViewModel
                 Documents.RemoveAt(0);
             }*/
 
-            OpenFile(file);
-
-            CloseWelcomeScreen();
+            await OpenFile(file);
 
             Analytics.TrackEvent("Document_Open");
         }
@@ -113,10 +113,7 @@ public partial class MainViewModel
         XamlDocument openDoc = OpenFiles.FirstOrDefault(f => f?.BackingFile?.Path == file.Path);
         if (openDoc != null)
         {
-            if (openDoc.ParentFolder == null)
-            {
-                openDoc.ParentFolder = workspace;
-            }
+            openDoc.ParentFolder ??= workspace;
 
             ActiveFile = openDoc;
         }
@@ -141,8 +138,10 @@ public partial class MainViewModel
     [RelayCommand]
     private async Task OpenFolderPicker()
     {
-        var picker = new FolderPicker();
-        picker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
+        var picker = new FolderPicker
+        {
+            SuggestedStartLocation = PickerLocationId.DocumentsLibrary
+        };
         picker.FileTypeFilter.Add("*");
 
         var folder = await picker.PickSingleFolderAsync();
@@ -261,10 +260,12 @@ public partial class MainViewModel
 
     private async Task<StorageFile> SaveFileDialog(string documentName)
     {
-        var savePicker = new FileSavePicker();
-        savePicker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
+        var savePicker = new FileSavePicker
+        {
+            SuggestedStartLocation = PickerLocationId.DocumentsLibrary
+        };
         // Dropdown of file types the user can save the file as
-        savePicker.FileTypeChoices.Add("eXtended Application Markup Language", new List<string>() { ".xaml" });
+        savePicker.FileTypeChoices.Add("eXtended Application Markup Language", [".xaml"]);
         // Default file name if the user does not type one in or select a file to replace
         savePicker.SuggestedFileName = documentName;
 
@@ -274,11 +275,11 @@ public partial class MainViewModel
     [RelayCommand]
     private async Task<bool> SaveDocument(XamlDocument document)
     {
-        StorageFile file = null;
 
         // Ensure if we can restore the file if it wasn't available on load
         await document.RestoreFileAsync();
 
+        StorageFile file;
         // Save As
         if (!document.CanSave)
         {

--- a/XamlStudio/ViewModels/MainViewModel.cs
+++ b/XamlStudio/ViewModels/MainViewModel.cs
@@ -19,15 +19,13 @@ public partial class MainViewModel : WorkspaceWindow
     /// </summary>
     private int _untitledCount = 1;
 
-    public Dictionary<XamlDocument, DocumentViewModel> DocumentViewModels { get; } = new Dictionary<XamlDocument, DocumentViewModel>();
+    public Dictionary<XamlDocument, DocumentViewModel> DocumentViewModels { get; } = [];
 
     [ObservableProperty]
     public partial DocumentViewModel ActiveDocumentViewModel { get; set; }
 
     partial void OnActiveDocumentViewModelChanged(DocumentViewModel oldValue, DocumentViewModel newValue)
-    {
-        WeakReferenceMessenger.Default.Send<ActiveDocumentViewModelChangedMessage>(new(oldValue, newValue));
-    }
+        => WeakReferenceMessenger.Default.Send<ActiveDocumentViewModelChangedMessage>(new(oldValue, newValue));
 
     public SettingsPanelViewModel SettingsViewModel { get; } = new SettingsPanelViewModel();
 
@@ -66,10 +64,7 @@ public partial class MainViewModel : WorkspaceWindow
         }
 
         // If no active file was set, set it to the last one. (Rehydrate if on settings/welcome from old version).
-        if (ActiveFile == null)
-        {
-            ActiveFile = OpenFiles.Last();
-        }
+        ActiveFile ??= OpenFiles.Last();
     }
 
     private void OpenFiles_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)

--- a/XamlStudio/ViewModels/SettingsPanelViewModel.cs
+++ b/XamlStudio/ViewModels/SettingsPanelViewModel.cs
@@ -46,7 +46,7 @@ public partial class SettingsPanelViewModel : ObservableObject
 
     public SettingsService Settings { get; } = SettingsService.Instance;
 
-    public ObservableCollection<ThirdPartyInfo> ThirdPartyLibs { get; set; } = new ObservableCollection<ThirdPartyInfo>();
+    public ObservableCollection<ThirdPartyInfo> ThirdPartyLibs { get; set; } = [];
 
     public SettingsPanelViewModel()
     {
@@ -97,13 +97,9 @@ public partial class SettingsPanelViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private void DelayChanged(RangeBaseValueChangedEventArgs args)
-    {
-        Settings.AutoCompileDelay = args.NewValue;
-
-        // TODO: Need to use a ThreadPoolTimer to wait for last change?
-        ////Analytics.TrackEvent("Settings_CompileDelayChanged", new Dictionary<string, string> {
-        ////    { "Value", "" + args.NewValue },
-        ////});
-    }
+    private void DelayChanged(RangeBaseValueChangedEventArgs args) => Settings.AutoCompileDelay = args.NewValue;
+    // TODO: Need to use a ThreadPoolTimer to wait for last change?
+    ////Analytics.TrackEvent("Settings_CompileDelayChanged", new Dictionary<string, string> {
+    ////    { "Value", "" + args.NewValue },
+    ////});
 }

--- a/XamlStudio/ViewModels/ToolboxViewModel.cs
+++ b/XamlStudio/ViewModels/ToolboxViewModel.cs
@@ -25,7 +25,7 @@ public partial class ToolboxViewModel : ObservableObject
         IsSourceGrouped = true
     };
 
-    public ObservableCollection<Type> Favorites { get; } = new ObservableCollection<Type>();
+    public ObservableCollection<Type> Favorites { get; } = [];
 
     [ObservableProperty]
     public partial string Filter { get; set; } = string.Empty;
@@ -88,8 +88,7 @@ public partial class ToolboxViewModel : ObservableObject
     }
 
     partial void OnFilterChanged(string value)
-    {
-        LibraryView.Source = _groupedSource
+        => LibraryView.Source = _groupedSource
             .SelectMany(group => group)
             .Where(t => t.Name.Contains(value, StringComparison.OrdinalIgnoreCase) || t.Namespace.Contains(value, StringComparison.OrdinalIgnoreCase) || t.BaseType.Name.Contains(value, StringComparison.OrdinalIgnoreCase))
             .ToGroup(api => api.Namespace)
@@ -98,5 +97,4 @@ public partial class ToolboxViewModel : ObservableObject
                 .Where(t => t.Name.Contains(value, StringComparison.OrdinalIgnoreCase) || t.Namespace.Contains(value, StringComparison.OrdinalIgnoreCase) || t.BaseType.Name.Contains(value, StringComparison.OrdinalIgnoreCase))
                 .OrderBy(t => t.Name)
                 .ToGroup("Toolbox_Favorites_Header".GetLocalized()));
-    }
 }

--- a/XamlStudio/Views/Binding.xaml.cs
+++ b/XamlStudio/Views/Binding.xaml.cs
@@ -57,8 +57,5 @@ public sealed partial class Binding : Page
         }
     }
 
-    private void Button_ClearHistoryFilter_Click(object sender, RoutedEventArgs e)
-    {
-        HistoryFilter = null;
-    }
+    private void Button_ClearHistoryFilter_Click(object sender, RoutedEventArgs e) => HistoryFilter = null;
 }

--- a/XamlStudio/Views/DataSources.xaml.cs
+++ b/XamlStudio/Views/DataSources.xaml.cs
@@ -156,9 +156,11 @@ public sealed partial class DataSources : Page,
 
     private async void Open_DataSource(object sender, RoutedEventArgs e)
     {
-        var picker = new FileOpenPicker();
-        picker.ViewMode = PickerViewMode.List;
-        picker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
+        var picker = new FileOpenPicker
+        {
+            ViewMode = PickerViewMode.List,
+            SuggestedStartLocation = PickerLocationId.DocumentsLibrary
+        };
         picker.FileTypeFilter.Add(".json");
 
         var file = await picker.PickSingleFileAsync();
@@ -174,11 +176,11 @@ public sealed partial class DataSources : Page,
 
     private async void Save_DataSource(object sender, RoutedEventArgs e)
     {
-        StorageFile file = null;
 
         // Ensure if we can restore the file if it wasn't available on load
         await _activeDocument.DataContext.RestoreFileAsync();
 
+        StorageFile file;
         // Save As
         if (!_activeDocument.DataContext.CanSave)
         {
@@ -236,10 +238,12 @@ public sealed partial class DataSources : Page,
 
     private async Task<StorageFile> SaveFileDialog(string documentName)
     {
-        var savePicker = new FileSavePicker();
-        savePicker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
+        var savePicker = new FileSavePicker
+        {
+            SuggestedStartLocation = PickerLocationId.DocumentsLibrary
+        };
         // Dropdown of file types the user can save the file as
-        savePicker.FileTypeChoices.Add("JavaScript Object Notation", new List<string>() { ".json" });
+        savePicker.FileTypeChoices.Add("JavaScript Object Notation", [".json"]);
         // Default file name if the user does not type one in or select a file to replace
         savePicker.SuggestedFileName = documentName;
 

--- a/XamlStudio/Views/Document.Design.xaml.cs
+++ b/XamlStudio/Views/Document.Design.xaml.cs
@@ -249,15 +249,15 @@ public partial class Document :
             if (targetLine.Contains(message.Property))
             {
                 var sp = targetLine.IndexOf(message.Property + "=") + message.Property.Length + 2;
-                lines[loc.Line - 1] = targetLine.Substring(0, sp) + $"{message.Value}" + targetLine.Substring(targetLine.IndexOf("\"", sp + 1));
+                lines[loc.Line - 1] = targetLine[..sp] + $"{message.Value}" + targetLine[targetLine.IndexOf("\"", sp + 1)..];
             }
             else if (targetLine.Trim().EndsWith("/>"))
             {
-                lines[loc.Line - 1] = targetLine.Substring(0, targetLine.Length - 2) + $" {message.Property}=\"{message.Value}\"/>";
+                lines[loc.Line - 1] = targetLine[..^2] + $" {message.Property}=\"{message.Value}\"/>";
             }
             else if (targetLine.Trim().EndsWith(">"))
             {
-                lines[loc.Line - 1] = targetLine.Substring(0, targetLine.Length - 1) + $" {message.Property}=\"{message.Value}\">";
+                lines[loc.Line - 1] = targetLine[..^1] + $" {message.Property}=\"{message.Value}\">";
             }
             else
             {

--- a/XamlStudio/Views/Document.xaml.cs
+++ b/XamlStudio/Views/Document.xaml.cs
@@ -92,7 +92,7 @@ public sealed partial class Document : UserControl,
     public static readonly DependencyProperty IsSpecificPreviewSizeProperty =
         DependencyProperty.Register(nameof(IsSpecificPreviewSize), typeof(bool), typeof(Document), new PropertyMetadata(false));
 
-    public ObservableCollection<BreadcrumbInfo> Breadcrumbs = new();
+    public ObservableCollection<BreadcrumbInfo> Breadcrumbs = [];
 
     public Document()
     {
@@ -115,17 +115,14 @@ public sealed partial class Document : UserControl,
 
         // HACK: TODO: Workaround for Monaco editor not updating it's content?
         ViewModel.Document.Content = ViewModel.Document.Content + " ";
-        ViewModel.Document.Content = ViewModel.Document.Content.Substring(0, ViewModel.Document.Content.Length - 1);
+        ViewModel.Document.Content = ViewModel.Document.Content[..^1];
 
         _ = UpdateBreadcrumbs();
 
         SetPaneOrientation();
     }
 
-    private void Document_Unloaded(object sender, RoutedEventArgs e)
-    {
-        WeakReferenceMessenger.Default.UnregisterAll(this);
-    }
+    private void Document_Unloaded(object sender, RoutedEventArgs e) => WeakReferenceMessenger.Default.UnregisterAll(this);
 
     private void UnloadViewModel(DocumentViewModel model)
     {
@@ -203,10 +200,7 @@ public sealed partial class Document : UserControl,
         });
     }
 
-    public async void Receive(NavigateToLineMessage message)
-    {
-        await CodeEditor.RevealLineInCenterIfOutsideViewportAsync(message.Line);
-    }
+    public async void Receive(NavigateToLineMessage message) => await CodeEditor.RevealLineInCenterIfOutsideViewportAsync(message.Line);
 
     public void Receive(InsertTextMessage message)
     {
@@ -469,13 +463,11 @@ public sealed partial class Document : UserControl,
     }
 
     private void CodeEditor_OpenLinkRequested(WebView sender, WebViewNewWindowRequestedEventArgs args)
-    {
-        Analytics.TrackEvent("Open_Docs", new Dictionary<string, string> {
-            { "Location", "CodeEditor" },
-            { "Type", _lastHoverType?.FullName ?? "Unknown" },
-            { "Uri", args.Uri.ToString() },
-        });
-    }
+        => Analytics.TrackEvent("Open_Docs", new Dictionary<string, string> {
+                { "Location", "CodeEditor" },
+                { "Type", _lastHoverType?.FullName ?? "Unknown" },
+                { "Uri", args.Uri.ToString() },
+            });
 
     private void DocumentState_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
@@ -495,10 +487,7 @@ public sealed partial class Document : UserControl,
         var orientation = LoadedDocument.State.PreviewOrientation;
 
         // If we're set to default, go grab that value to start from
-        if (orientation == null)
-        {
-            orientation = SettingsService.Instance.DefaultPreviewPanePosition;
-        }
+        orientation ??= SettingsService.Instance.DefaultPreviewPanePosition;
 
         switch (orientation.Value)
         {
@@ -529,12 +518,9 @@ public sealed partial class Document : UserControl,
     }
 
     #region Share Button Code
-    private readonly Lazy<CanvasDevice> _device = new Lazy<CanvasDevice>(InitCanvas);
+    private readonly Lazy<CanvasDevice> _device = new(InitCanvas);
 
-    private static CanvasDevice InitCanvas()
-    {
-        return CanvasDevice.GetSharedDevice();
-    }
+    private static CanvasDevice InitCanvas() => CanvasDevice.GetSharedDevice();
 
     private CanvasBitmap _screenshotImage;
 
@@ -545,10 +531,7 @@ public sealed partial class Document : UserControl,
         DataTransferManager.ShowShareUI();
     }
 
-    private void ShareMenuEntireWindow_Click(object sender, RoutedEventArgs e)
-    {
-        ShareButton_Click(null, null);
-    }
+    private void ShareMenuEntireWindow_Click(object sender, RoutedEventArgs e) => ShareButton_Click(null, null);
 
     private async void ShareMenuPreviewOnly_Click(object sender, RoutedEventArgs e)
     {
@@ -566,7 +549,7 @@ public sealed partial class Document : UserControl,
 
             args.Request.Data.Properties.Title = "XAML Studio - " + LoadedDocument.Title;
 
-            InMemoryRandomAccessStream inMemoryStream = new InMemoryRandomAccessStream();
+            InMemoryRandomAccessStream inMemoryStream = new();
 
             await _screenshotImage.SaveAsync(inMemoryStream, CanvasBitmapFileFormat.Png); // TODO: Have Option for quality?
 
@@ -612,10 +595,7 @@ public sealed partial class Document : UserControl,
         }
     }
 
-    private void CodeEditor_SelectedRangeChanged(DependencyObject sender, DependencyProperty dp)
-    {
-        _ = UpdateBreadcrumbs();
-    }
+    private void CodeEditor_SelectedRangeChanged(DependencyObject sender, DependencyProperty dp) => _ = UpdateBreadcrumbs();
 
     private async Task UpdateBreadcrumbs()
     {

--- a/XamlStudio/Views/DocumentToViewModelConverter.cs
+++ b/XamlStudio/Views/DocumentToViewModelConverter.cs
@@ -30,8 +30,5 @@ public class DocumentToViewModelConverter : IValueConverter
         return DependencyProperty.UnsetValue;
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, string language)
-    {
-        throw new NotImplementedException();
-    }
+    public object ConvertBack(object value, Type targetType, object parameter, string language) => throw new NotImplementedException();
 }

--- a/XamlStudio/Views/Explorer.xaml.cs
+++ b/XamlStudio/Views/Explorer.xaml.cs
@@ -60,10 +60,12 @@ public sealed partial class Explorer : Page
     private void InitializeTreeView(FolderLocation folder)
     {
         // FYI A TreeView can have more than 1 root node. TODO: Support multiple workspaces? Or would we just separate outside the TreeView anyway?
-        muxc.TreeViewNode mainNode = new muxc.TreeViewNode();
-        mainNode.Content = folder.BackingFolder;
-        mainNode.IsExpanded = true;
-        mainNode.HasUnrealizedChildren = true;
+        muxc.TreeViewNode mainNode = new()
+        {
+            Content = folder.BackingFolder,
+            IsExpanded = true,
+            HasUnrealizedChildren = true
+        };
         FillTreeNode(mainNode);
 
         WorkspaceTreeView.RootNodes.Add(mainNode);
@@ -76,8 +78,7 @@ public sealed partial class Explorer : Page
         // Add each item as a new child node of the node that's being expanded.
 
         // Only process the node if it's a folder and has unrealized children.
-        StorageFolder folder = null;
-
+        StorageFolder folder;
         if (node.Content is StorageFolder && node.HasUnrealizedChildren == true)
         {
             folder = node.Content as StorageFolder;
@@ -99,8 +100,10 @@ public sealed partial class Explorer : Page
 
         foreach (var item in itemsList)
         {
-            var newNode = new muxc.TreeViewNode();
-            newNode.Content = item;
+            var newNode = new muxc.TreeViewNode
+            {
+                Content = item
+            };
 
             if (item is StorageFolder)
             {
@@ -160,12 +163,12 @@ public sealed partial class Explorer : Page
             case StorageFile file when ExplorerItemTemplateSelector.DataFileTypes.Contains(file.FileType.ToLower()):
                 // Insert the d:DataContext="{d:DesignData /SampleData/XAMLing.json}" attribute
                 // TODO: Should we instead explicitly update/insert this into root tag?
-                WeakReferenceMessenger.Default.Send<InsertTextMessage>(new($"d:DataContext=\"{{d:DesignData {file.Path.Replace('\\', '/').Substring(workspacePathLength)}}}\""));
+                WeakReferenceMessenger.Default.Send<InsertTextMessage>(new($"d:DataContext=\"{{d:DesignData {file.Path.Replace('\\', '/')[workspacePathLength..]}}}\""));
                 Analytics.TrackEvent("Explorer_Workspace_InsertDataContext");
                 break;
             case StorageFile file when ExplorerItemTemplateSelector.ImageFileTypes.Contains(file.FileType.ToLower()):
                 // Insert image tag into document
-                WeakReferenceMessenger.Default.Send<InsertTextMessage>(new($"<Image Source=\"{file.Path.Replace('\\', '/').Substring(workspacePathLength)}\" />"));
+                WeakReferenceMessenger.Default.Send<InsertTextMessage>(new($"<Image Source=\"{file.Path.Replace('\\', '/')[workspacePathLength..]}\" />"));
                 Analytics.TrackEvent("Explorer_Workspace_InsertImage");
                 break;
             case StorageFile file when ExplorerItemTemplateSelector.XamlFileTypes.Contains(file.FileType.ToLower()):

--- a/XamlStudio/Views/MainPage.xaml.cs
+++ b/XamlStudio/Views/MainPage.xaml.cs
@@ -80,11 +80,9 @@ public sealed partial class MainPage : Page, IFileOpener,
     }
 
     private void CoreTitleBar_LayoutMetricsChanged(CoreApplicationViewTitleBar sender, object args)
-    {
-        // Get the size of the caption controls and set padding.
-        ////LeftPaddingColumn.Width = new GridLength(coreTitleBar.SystemOverlayLeftInset);
-        RightPaddingColumn.Width = new GridLength(sender.SystemOverlayRightInset);
-    }
+         // Get the size of the caption controls and set padding.
+         ////LeftPaddingColumn.Width = new GridLength(coreTitleBar.SystemOverlayLeftInset);
+         => RightPaddingColumn.Width = new GridLength(sender.SystemOverlayRightInset);
 
     private void Instance_OnBackgroundEntering(object sender, OnBackgroundEnteringEventArgs e)
     {
@@ -228,7 +226,7 @@ public sealed partial class MainPage : Page, IFileOpener,
     private async void MainPage_Loaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
     {
         // Offload from main thread to parallelize assembly loading.
-        Task t = new Task(async () =>
+        Task t = new(async () =>
         {
             // TODO: Clean-up these initialize calls to make sure this list is centralized...
             await AppAssemblyInfo.Instance.InitializeAsync(new Assembly[] {
@@ -396,9 +394,7 @@ public sealed partial class MainPage : Page, IFileOpener,
     }
 
     private void DocumentTabs_TabClosing(Microsoft.UI.Xaml.Controls.TabView sender, Microsoft.UI.Xaml.Controls.TabViewTabCloseRequestedEventArgs args)
-    {
-        ViewModel.CloseActiveDocumentCommand.Execute(args.Item);
-    }
+        => ViewModel.CloseActiveDocumentCommand.Execute(args.Item);
 
     private void NavMenu_ItemInvoked(MUXC.NavigationView sender, MUXC.NavigationViewItemInvokedEventArgs args)
     {

--- a/XamlStudio/Views/Properties.xaml.cs
+++ b/XamlStudio/Views/Properties.xaml.cs
@@ -124,10 +124,7 @@ public sealed partial class Properties : Page,
         }
     }
 
-    public void Receive(SelectedVisualElementMessage message)
-    {
-        UpdateProperties(message.Element);
-    }
+    public void Receive(SelectedVisualElementMessage message) => UpdateProperties(message.Element);
 
     public void Receive(EditorSelectedElementMessage message)
     {
@@ -156,7 +153,7 @@ public sealed partial class Properties : Page,
 
             if (VisualTreeHelper.GetChildrenCount(element) is int count && count > 0)
             {
-                List<DependencyObject> children = new();
+                List<DependencyObject> children = [];
                 for (int i = 0; i < count; i++)
                 {
                     children.Add(VisualTreeHelper.GetChild(element, i));
@@ -169,8 +166,8 @@ public sealed partial class Properties : Page,
             }
 
             // Find properties of interest...
-            List<PropertyInfo> properties = new();
-            List<PropertyInfo> unsetProperties = new();
+            List<PropertyInfo> properties = [];
+            List<PropertyInfo> unsetProperties = [];
 
             // Helper Function to Add Property Values to our List (if value is set)
             PropertyInfo AddProperty(Type type, string propName, string? group = null)
@@ -202,7 +199,7 @@ public sealed partial class Properties : Page,
 
             // TODO: Pinned...
 
-            HashSet<string> definedAttributes = new();
+            HashSet<string> definedAttributes = [];
 
             // Check if we have an associated XML element to see what we set in our Editor text
             if (xmlHint == null
@@ -216,7 +213,7 @@ public sealed partial class Properties : Page,
                 }
             }
 
-            List<string> groupOrder = new() { "- Modified -", "- Set in XAML -" };
+            List<string> groupOrder = ["- Modified -", "- Set in XAML -"];
 
             PropertyInfo unset = null;
 
@@ -255,7 +252,7 @@ public sealed partial class Properties : Page,
                                                 .OrderBy(g => groupOrder.IndexOf(g.Key)));
 
             // Check for Visual States
-            ViewModel.VisualStates = new();
+            ViewModel.VisualStates = [];
             if (element is FrameworkElement fe)
             {
                 _visualStateWatcher = new(fe);

--- a/XamlStudio/Views/SettingsPanelPage.xaml.cs
+++ b/XamlStudio/Views/SettingsPanelPage.xaml.cs
@@ -180,10 +180,7 @@ public sealed partial class SettingsPanelPage : Page
         }
     }
 
-    private async Task<bool> AreAnalyticsOn()
-    {
-        return await Analytics.IsEnabledAsync();
-    }
+    private async Task<bool> AreAnalyticsOn() => await Analytics.IsEnabledAsync();
 
     public Visibility FeedbackVisibility => StoreServicesFeedbackLauncher.IsSupported() ? Visibility.Visible : Visibility.Collapsed;
 

--- a/XamlStudio/Views/StorageFileThumbnailConverter.cs
+++ b/XamlStudio/Views/StorageFileThumbnailConverter.cs
@@ -27,20 +27,17 @@ public class StorageFileThumbnailConverter : IValueConverter
         if (value is StorageFile file)
         {
             var result = new BitmapImage();
-            Task t = new Task(async () =>
+            Task t = new(async () =>
             {
                 if (file.IsAvailable)
                 {
                     var thumbnail = await file.GetScaledImageAsThumbnailAsync(Windows.Storage.FileProperties.ThumbnailMode.PicturesView, 128, Windows.Storage.FileProperties.ThumbnailOptions.ResizeThumbnail);
 
-                    if (thumbnail == null)
-                    {
-                        thumbnail = await file.GetThumbnailAsync(Windows.Storage.FileProperties.ThumbnailMode.PicturesView, 128, Windows.Storage.FileProperties.ThumbnailOptions.ResizeThumbnail);
-                    }
+                    thumbnail ??= await file.GetThumbnailAsync(Windows.Storage.FileProperties.ThumbnailMode.PicturesView, 128, Windows.Storage.FileProperties.ThumbnailOptions.ResizeThumbnail);
 
                     if (thumbnail != null)
                     {
-                        InMemoryRandomAccessStream randomAccessStream = new InMemoryRandomAccessStream();
+                        InMemoryRandomAccessStream randomAccessStream = new();
                         await RandomAccessStream.CopyAsync(thumbnail, randomAccessStream);
                         randomAccessStream.Seek(0);
                         await _queue.EnqueueAsync(async () =>
@@ -67,8 +64,5 @@ public class StorageFileThumbnailConverter : IValueConverter
         return DependencyProperty.UnsetValue;
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, string language)
-    {
-        throw new NotImplementedException();
-    }
+    public object ConvertBack(object value, Type targetType, object parameter, string language) => throw new NotImplementedException();
 }

--- a/XamlStudio/Views/WelcomePage.xaml.cs
+++ b/XamlStudio/Views/WelcomePage.xaml.cs
@@ -26,7 +26,7 @@ public sealed partial class WelcomePage : Page
     public static readonly DependencyProperty MainViewModelProperty =
         DependencyProperty.Register("MainViewModel", typeof(MainViewModel), typeof(WelcomePage), new PropertyMetadata(null));
 
-    public ObservableCollection<StorageFile> RecentFiles { get; set; } = new ObservableCollection<StorageFile>();
+    public ObservableCollection<StorageFile> RecentFiles { get; set; } = [];
 
     public WelcomePage()
     {


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! ⚠ -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Fixes  #60 

<!-- Add the relevant issue number after the word "Fixes" mentioned above (for ex: `## Fixes #0000`) which will automatically close the issue once the PR is merged. -->

<!-- PRs without assigned issues will be closed unless minor changes to documentation/typos. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

This PR refactors the XAML Studio codebase to make more extensive use of modern C# features. The refactor was performed using various Roslyn analyzers. All transformations to the code were carefully reviewed, and reformatted where necessary to follow the conventions of adjacent code. 

For the most part, this is a "pure" refactor, but a couple semantic changes are included:
- `ActivationHandler` was updated to avoid the `is`/`as` anti-pattern.
- `MainWindowViewModel.OpenDocument` was updated to await the `OpenFile` call and the `CloseWelcomeScreen` call was removed as `OpenFile` already calls it.

I am also not sure about the constructor comment moved to the top of `XamlRenderResultContext` following the promotion to primary constructor. It's a little awkward, but I left it.

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->

<!-- - Bugfix -->
<!-- - Code style update (formatting) -->
- Refactoring (no functional changes, no api changes)
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

No significant behavioral changes.

## What is the new behavior?

No significant behavioral changes.

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest dev branch of XAML Studio
- [x] Tested code with current supported SDKs
- [x] Tests for the changes have been added (if applicable)
- [x] License Header has been added to all new source files
- [x] Contains **NO** breaking changes to save/state files

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->
